### PR TITLE
Add endpoint to GET Artist data

### DIFF
--- a/1. Clients/MusicAPI/Controllers/ArtistController.cs
+++ b/1. Clients/MusicAPI/Controllers/ArtistController.cs
@@ -6,40 +6,34 @@ using System.ComponentModel.DataAnnotations;
 namespace MusicAPI.Controllers
 {
     /// <summary>
-    /// Controller for Client integration targeting Spotify's Web API.
+    /// Controller for Client integration targeting Spotify's Web API, specifially around Artists information.
     /// </summary>
     /// <param name="spotifyManager"></param>
     [ApiController]
     [Route("api/[controller]")]
-    public class SpotifyController(ISpotifyManager spotifyManager) : ControllerBase
+    public class ArtistController(ISpotifyManager spotifyManager) : ControllerBase
     {
         /// <summary>
-        ///     Get detailed profile information about the current user (including the current user's username)
+        /// Retrieves Spotify catalog information for a single artist identified by their unique Spotify ID.
         /// </summary>
-        /// <returns>
-        ///     Detailed profile information about the current authorized user.
-        /// </returns>
+        /// <param name="artistId">The unique spotify artist id returned from GET Search</param>
+        /// <returns></returns>
         [HttpGet]
-        [Route("/GetAccountDetails")]
+        [Route("/Artist")]
         [Produces(typeof(OkObjectResult))]
-        public async Task<IActionResult> GetAccountDetails()
+        public async Task<IActionResult> GetArtistAsync([Required] string artistId)
         {
-            var spotifyAccount = await spotifyManager
-                .GetSpotifyAccountAsync();
+            var artist = await spotifyManager
+                .GetArtistAsync(artistId);
 
-            return Ok(spotifyAccount);
+            return Ok(artist);
         }
 
         /// <summary>
-        ///     Returns Spotify catalog information about Albums, Artists, Playlists, Tracks, Shows, Episodes,
-        ///     or Audiobooks that match a keyword string. Audiobooks are only available within the US, UK, Canada, Ireland,
-        ///     New Zealand and Australia markets.
+        ///     Returns Spotify catalog information about Artists that match a keyword string.
         /// </summary>
         /// <param name="searchQuery">
         ///     The search query.
-        /// </param>
-        /// <param name="searchType">
-        ///     Item type to execute the search across.
         /// </param>
         /// <param name="marketCode">
         ///     An ISO 3166-1 alpha-2 country code.
@@ -63,32 +57,15 @@ namespace MusicAPI.Controllers
         [Produces(typeof(OkObjectResult))]
         public async Task<IActionResult> GetSearchAsync(
             [Required] string searchQuery,
-            [Required] SearchType searchType,
             [Required] string marketCode,
             int? limit = null,
             int? offset = null,
             string? includeExternal = null)
         {
             var searchResult = await spotifyManager
-                .GetSearchAsync(searchQuery, searchType, marketCode, limit, offset, includeExternal);
+                .GetSearchAsync(searchQuery, SearchType.Artist, marketCode, limit, offset, includeExternal);
 
             return Ok(searchResult);
-        }
-
-        /// <summary>
-        /// Retrieves Spotify catalog information for a single artist identified by their unique Spotify ID.
-        /// </summary>
-        /// <param name="artistId">The unique spotify artist id returned from GET Search</param>
-        /// <returns></returns>
-        [HttpGet]
-        [Route("/Artist")]
-        [Produces(typeof(OkObjectResult))]
-        public async Task<IActionResult> GetArtistAsync([Required] string artistId)
-        {
-            var artist = await spotifyManager
-                .GetArtistAsync(artistId);
-
-            return Ok(artist);
         }
     }
 }

--- a/1. Clients/MusicAPI/Controllers/SpotifyController.cs
+++ b/1. Clients/MusicAPI/Controllers/SpotifyController.cs
@@ -74,5 +74,21 @@ namespace MusicAPI.Controllers
 
             return Ok(searchResult);
         }
+
+        /// <summary>
+        /// Retrieves Spotify catalog information for a single artist identified by their unique Spotify ID.
+        /// </summary>
+        /// <param name="artistId">The unique spotify artist id returned from GET Search</param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("/Artist")]
+        [Produces(typeof(OkObjectResult))]
+        public async Task<IActionResult> GetArtistAsync([Required] string artistId)
+        {
+            var artist = await spotifyManager
+                .GetArtistAsync(artistId);
+
+            return Ok(artist);
+        }
     }
 }

--- a/1. Clients/MusicAPI/Controllers/UsersController.cs
+++ b/1. Clients/MusicAPI/Controllers/UsersController.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using MusicAPI.Managers.Interfaces;
+using MusicAPI.Managers.ViewModels.Enums;
+using System.ComponentModel.DataAnnotations;
+
+namespace MusicAPI.Controllers
+{
+    /// <summary>
+    /// Controller for Client integration targeting Spotify's Web API, specifially around Users information.
+    /// </summary>
+    /// <param name="spotifyManager"></param>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UsersController(ISpotifyManager spotifyManager) : ControllerBase
+    {
+        /// <summary>
+        ///     Get detailed profile information about the current user (including the current user's username)
+        /// </summary>
+        /// <returns>
+        ///     Detailed profile information about the current authorized user.
+        /// </returns>
+        [HttpGet]
+        [Route("/GetAccountDetails")]
+        [Produces(typeof(OkObjectResult))]
+        public async Task<IActionResult> GetAccountDetails()
+        {
+            var spotifyAccount = await spotifyManager
+                .GetSpotifyAccountAsync();
+
+            return Ok(spotifyAccount);
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
@@ -28,5 +28,7 @@ namespace MusicAPI.Managers.Interfaces
             int? limit = 20,
             int? offset = 0,
             string? includeExternal = "");
+
+        Task<ViewModels.Artist> GetArtistAsync(string artistId);
     }
 }

--- a/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
@@ -29,6 +29,11 @@ namespace MusicAPI.Managers.Interfaces
             int? offset = 0,
             string? includeExternal = "");
 
+        /// <summary>
+        /// Manager method for directing traffic to retrieve Artist data from Spotify's GET /artist/{id} endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <returns></returns>
         Task<ViewModels.Artist> GetArtistAsync(string artistId);
     }
 }

--- a/2. Managers/MusicAPI.Managers/SpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/SpotifyManager.cs
@@ -53,5 +53,20 @@ namespace MusicAPI.Managers
             return mapper
                 .Map<ViewModels.SearchResult>(searchResultDto);
         }
+
+        public async Task<ViewModels.Artist> GetArtistAsync(string artistId)
+        {
+            var bearerToken = await authorizationAccessor
+                .RequestAccessTokenAsync();
+
+            var queryString = queryEngine
+                .BuildGetArtistQueryString(artistId);
+
+            var artistDto = await spotifyAccessor
+                .GetArtistAsync(bearerToken, queryString);
+
+            return mapper
+                .Map<ViewModels.Artist>(artistDto);
+        }
     }
 }

--- a/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
@@ -25,5 +25,12 @@
             int? limit,
             int? offset,
             string? includeExternal);
+
+        /// <summary>
+        /// Responsible for building a query string that targets Spotify's Web API GET /artists/{id} endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <returns></returns>
+        string BuildGetArtistQueryString(string artistId);
     }
 }

--- a/3. Engines/MusicAPI.Engines/QueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/QueryEngine.cs
@@ -43,5 +43,10 @@ namespace MusicAPI.Engines
 
             return requestString;
         }
+
+        public string BuildGetArtistQueryString(string artistId)
+        {
+            return $"{SpotifyBaseUri}/artists/{artistId}";
+        }
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Artist.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Artist.cs
@@ -11,7 +11,7 @@ namespace MusicAPI.Accessors.DataTransferObjects
         public Followers Followers { get; set; } = new Followers();
 
         [JsonPropertyName("genres")]
-        public string[] Genres { get; set; } = Array.Empty<string>();
+        public string[] Genres { get; set; } = [];
 
         [JsonPropertyName("href")]
         public string Href { get; set; } = string.Empty;
@@ -20,7 +20,7 @@ namespace MusicAPI.Accessors.DataTransferObjects
         public string Id {  get; set; } = string.Empty;
 
         [JsonPropertyName("images")]
-        public Image[] Images { get; set; } = Array.Empty<Image>();
+        public Image[] Images { get; set; } = [];
 
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Artist.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Artist.cs
@@ -26,7 +26,7 @@ namespace MusicAPI.Accessors.DataTransferObjects
         public string Name { get; set; } = string.Empty;
 
         [JsonPropertyName("popularity")]
-        public int Popularity { get; set; } = 0;
+        public decimal Popularity { get; set; } = 0;
 
         [JsonPropertyName("type")]
         public string Type { get; set; } = string.Empty;

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Artists.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Artists.cs
@@ -23,6 +23,6 @@ namespace MusicAPI.Accessors.DataTransferObjects
         public int Total { get; set; } = 0;
 
         [JsonPropertyName("items")]
-        public Artist[] Items { get; set; } = Array.Empty<Artist>();
+        public Artist[] Items { get; set; } = [];
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/ExternalUrl.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/ExternalUrl.cs
@@ -7,15 +7,10 @@ namespace MusicAPI.Accessors.DataTransferObjects
     /// </summary>
     public class ExternalUrl
     {
-        public ExternalUrl()
-        {
-            Spotify = string.Empty;
-        }
-
         /// <summary>
         /// The Spotify URL for the object.
         /// </summary>
         [JsonPropertyName("spotify")]
-        public string Spotify {  get; set; }
+        public string Spotify {  get; set; } = string.Empty;
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Followers.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Followers.cs
@@ -7,22 +7,16 @@ namespace MusicAPI.Accessors.DataTransferObjects
     /// </summary>
     public class Followers
     {
-        public Followers()
-        {
-            Href = string.Empty;
-            Total = 0;
-        }
-
         /// <summary>
         /// This will alwaysb e set to null, as the Web API does not currently support it.
         /// </summary>
         [JsonPropertyName("href")]
-        public string Href { get; set; }
+        public string Href { get; set; } = string.Empty;
 
         /// <summary>
         /// Total number of followers.
         /// </summary>
         [JsonPropertyName("total")]
-        public int Total { get; set; }
+        public decimal Total { get; set; }
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Image.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Image.cs
@@ -7,29 +7,22 @@ namespace MusicAPI.Accessors.DataTransferObjects
     /// </summary>
     public class Image
     {
-        public Image()
-        {
-            Url = string.Empty;
-            Height = 0;
-            Width = 0;
-        }
-
         /// <summary>
         /// The source URL of the image.
         /// </summary>
         [JsonPropertyName("url")]
-        public string Url { get; set; }
+        public string Url { get; set; } = string.Empty;
 
         /// <summary>
         /// The image height in pixels.
         /// </summary>
         [JsonPropertyName("height")]
-        public int Height { get; set; }
+        public decimal Height { get; set; } = 0;
 
         /// <summary>
         /// The image width in pixels.
         /// </summary>
         [JsonPropertyName("width")]
-        public int Width { get; set; }
+        public decimal Width { get; set; } = 0;
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
@@ -19,5 +19,13 @@ namespace MusicAPI.Accessors.Interfaces
         /// <param name="queryString"></param>
         /// <returns></returns>
         Task<SearchResult> GetSearchAsync(string bearerToken, string queryString);
+
+        /// <summary>
+        /// Communicates with Spotify's Web API to retrieve catalog information for a single artist.
+        /// </summary>
+        /// <param name="bearerToken"></param>
+        /// <param name="queryString"></param>
+        /// <returns></returns>
+        Task<Artist> GetArtistAsync(string bearerToken, string queryString);
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -9,15 +9,7 @@ namespace MusicAPI.Accessors
     {
         public async Task<UserProfile> GetCurrentUserProfileAsync(string bearerToken, string queryString)
         {
-            if (string.IsNullOrWhiteSpace(bearerToken))
-            {
-                throw new ArgumentNullException(nameof(bearerToken));
-            }
-
-            if (string.IsNullOrWhiteSpace(queryString))
-            {
-                throw new ArgumentNullException(nameof(queryString));
-            }
+            ValidateParameters(bearerToken, queryString);
 
             var response = await ExecuteGetRequest(bearerToken, queryString);
 
@@ -38,21 +30,13 @@ namespace MusicAPI.Accessors
 
         public async Task<SearchResult> GetSearchAsync(string bearerToken, string queryString)
         {
-            if (string.IsNullOrWhiteSpace(bearerToken))
-            {
-                throw new ArgumentNullException(nameof(bearerToken));
-            }
-
-            if (string.IsNullOrWhiteSpace(queryString))
-            {
-                throw new ArgumentNullException(nameof(queryString));
-            }
+            ValidateParameters(bearerToken, queryString);
 
             var response = await ExecuteGetRequest(bearerToken, queryString);
 
             if (response.IsSuccessStatusCode)
             {
-                var responseContent =  await response
+                var responseContent = await response
                     .Content
                     .ReadAsStringAsync();
 
@@ -63,6 +47,27 @@ namespace MusicAPI.Accessors
             }
 
             throw new HttpRequestException($"Unable to retrieve Search Data using the request {queryString}");
+        }
+
+        public async Task<Artist> GetArtistAsync(string bearerToken, string queryString)
+        {
+            ValidateParameters(bearerToken, queryString);
+
+            var response = await ExecuteGetRequest(bearerToken, queryString);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var responseContent = await response
+                    .Content
+                    .ReadAsStringAsync();
+
+                var artist = JsonSerializer
+                    .Deserialize<Artist>(responseContent);
+
+                return artist ?? new Artist();
+            }
+
+            throw new HttpRequestException($"Unable to retrieve Artist data using the request {queryString}");
         }
 
         private async Task<HttpResponseMessage> ExecuteGetRequest(string bearerToken, string queryString)
@@ -86,6 +91,19 @@ namespace MusicAPI.Accessors
                 .Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
 
             return httpClient;
+        }
+
+        private void ValidateParameters(string bearerToken, string queryString)
+        {
+            if (string.IsNullOrWhiteSpace(bearerToken))
+            {
+                throw new ArgumentNullException(nameof(bearerToken));
+            }
+
+            if (string.IsNullOrWhiteSpace(queryString))
+            {
+                throw new ArgumentNullException(nameof(queryString));
+            }
         }
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -93,7 +93,7 @@ namespace MusicAPI.Accessors
             return httpClient;
         }
 
-        private void ValidateParameters(string bearerToken, string queryString)
+        private static void ValidateParameters(string bearerToken, string queryString)
         {
             if (string.IsNullOrWhiteSpace(bearerToken))
             {

--- a/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
+++ b/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
@@ -66,5 +66,21 @@
 
             Assert.That(queryString, Is.EqualTo(expectedQueryString));
         }
+
+        [Test]
+        public void BuildGetArtistQueryString_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildGetArtistQueryString("testId");
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/testId";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
     }
 }

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
@@ -12,10 +12,7 @@ namespace MusicAPI.Managers.Tests
         public async Task GetSpotifyAccoutnAsync_ShouldReturnUserProfile()
         {
             // Arrange
-            var mockAuthorizationAccessor = new Mock<IAuthorizationAccessor>(MockBehavior.Strict);
-            mockAuthorizationAccessor
-                .Setup(authorizationAccessor => authorizationAccessor.RequestAccessTokenAsync())
-                .ReturnsAsync("Bearer Token");
+            var mockAuthorizationAccessor = GetMockAuthorizationAccessor();
 
             var mockQueryEngine = new Mock<IQueryEngine>(MockBehavior.Strict);
             mockQueryEngine
@@ -57,10 +54,7 @@ namespace MusicAPI.Managers.Tests
         public async Task GetSearchAsync_ShouldReturnSearchResult()
         {
             // Arrange
-            var mockAuthorizationAccessor = new Mock<IAuthorizationAccessor>(MockBehavior.Strict);
-            mockAuthorizationAccessor
-                .Setup(authorizationAccessor => authorizationAccessor.RequestAccessTokenAsync())
-                .ReturnsAsync("Bearer Token");
+            var mockAuthorizationAccessor = GetMockAuthorizationAccessor();
 
             var mockQueryEngine = new Mock<IQueryEngine>(MockBehavior.Strict);
             mockQueryEngine
@@ -105,6 +99,58 @@ namespace MusicAPI.Managers.Tests
                         It.Is<string>(bearerToken => bearerToken.Equals("Bearer Token")),
                         It.Is<string>(queryString => queryString.Equals("http://localhost"))),
                     Times.Once);
+        }
+
+        [Test]
+        public async Task GetArtistAsync_ShouldReturnArtist()
+        {
+            var mockAuthorizationAccessor = GetMockAuthorizationAccessor();
+
+            var mockQueryEngine = new Mock<IQueryEngine>(MockBehavior.Strict);
+            mockQueryEngine
+                .Setup(queryEngine => queryEngine.BuildGetArtistQueryString(
+                    It.IsAny<string>()))
+                .Returns("http://localhost");
+
+            var mockSpotifyAccessor = new Mock<ISpotifyAccessor>(MockBehavior.Strict);
+            mockSpotifyAccessor
+                .Setup(spotifyAccessor => spotifyAccessor.GetArtistAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new Accessors.DataTransferObjects.Artist());
+
+            var mockMapper = new Mock<IMapper>(MockBehavior.Strict);
+            mockMapper
+                .Setup(mapper => mapper.Map<ViewModels.Artist>(It.IsAny<Accessors.DataTransferObjects.Artist>()))
+                .Returns(new ViewModels.Artist());
+
+            var spotifyManager = new SpotifyManager(
+                mockAuthorizationAccessor.Object,
+                mockMapper.Object,
+                mockSpotifyAccessor.Object,
+                mockQueryEngine.Object);
+
+            // Act
+            var artist = await spotifyManager
+                .GetArtistAsync("artistId");
+
+            // Assert/Verify
+            mockSpotifyAccessor
+                .Verify(spotifyAccessor =>
+                    spotifyAccessor.GetArtistAsync(
+                        It.Is<string>(bearerToken => bearerToken.Equals("Bearer Token")),
+                        It.Is<string>(queryString => queryString.Equals("http://localhost"))),
+                    Times.Once);
+        }
+
+        private static Mock<IAuthorizationAccessor> GetMockAuthorizationAccessor()
+        {
+            var mockAuthorizationAccessor = new Mock<IAuthorizationAccessor>(MockBehavior.Strict);
+            mockAuthorizationAccessor
+                .Setup(authorizationAccessor => authorizationAccessor.RequestAccessTokenAsync())
+                .ReturnsAsync("Bearer Token");
+
+            return mockAuthorizationAccessor;
         }
     }
 }

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
@@ -104,6 +104,7 @@ namespace MusicAPI.Managers.Tests
         [Test]
         public async Task GetArtistAsync_ShouldReturnArtist()
         {
+            // Arrange
             var mockAuthorizationAccessor = GetMockAuthorizationAccessor();
 
             var mockQueryEngine = new Mock<IQueryEngine>(MockBehavior.Strict);


### PR DESCRIPTION
This PR adds the following changes
- Split controllers up to be specific to the data category it will be retrieving (UsersController, ArtistController)
- Added manager/accessor/engine logic to facilitate building a query string and calling Spotify's GET Artist endpoint