### PR TITLE
Implement GET Artist Top Tracks endpoint

### DIFF
--- a/1. Clients/MusicAPI/Controllers/ArtistController.cs
+++ b/1. Clients/MusicAPI/Controllers/ArtistController.cs
@@ -19,7 +19,6 @@ namespace MusicAPI.Controllers
         /// <param name="artistId">The unique spotify artist id returned from GET Search</param>
         /// <returns></returns>
         [HttpGet]
-        [Route("/Artist")]
         [Produces(typeof(OkObjectResult))]
         public async Task<IActionResult> GetArtistAsync([Required] string artistId)
         {
@@ -53,7 +52,7 @@ namespace MusicAPI.Controllers
         ///     New Zealand and Australia markets.
         /// </returns>
         [HttpGet]
-        [Route("/Search")]
+        [Route("search")]
         [Produces(typeof(OkObjectResult))]
         public async Task<IActionResult> GetSearchAsync(
             [Required] string searchQuery,
@@ -66,6 +65,25 @@ namespace MusicAPI.Controllers
                 .GetSearchAsync(searchQuery, SearchType.Artist, marketCode, limit, offset, includeExternal);
 
             return Ok(searchResult);
+        }
+
+        /// <summary>
+        /// Gets Spotify catalog information about an artist's top tracks by country.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <param name="marketCode"></param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("topTracks")]
+        [Produces(typeof(OkObjectResult))]
+        public async Task<IActionResult> GetArtistTopTracksAsync(
+            [Required] string artistId,
+            [Required] string marketCode)
+        {
+            var topTracks = await spotifyManager
+                .GetArtistTopTracksAsync(artistId, marketCode);
+
+            return Ok(topTracks);
         }
     }
 }

--- a/1. Clients/MusicAPI/Controllers/UsersController.cs
+++ b/1. Clients/MusicAPI/Controllers/UsersController.cs
@@ -20,7 +20,7 @@ namespace MusicAPI.Controllers
         ///     Detailed profile information about the current authorized user.
         /// </returns>
         [HttpGet]
-        [Route("/GetAccountDetails")]
+        [Route("accountDetails")]
         [Produces(typeof(OkObjectResult))]
         public async Task<IActionResult> GetAccountDetails()
         {

--- a/1. Clients/MusicAPI/MusicAPI.csproj
+++ b/1. Clients/MusicAPI/MusicAPI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
@@ -35,5 +35,14 @@ namespace MusicAPI.Managers.Interfaces
         /// <param name="artistId"></param>
         /// <returns></returns>
         Task<ViewModels.Artist> GetArtistAsync(string artistId);
+
+        /// <summary>
+        /// Manager method for directing traffic to retrieve the Top Tracks for a given 
+        /// Artist using Spotify's GET /artist/{id}/top-tracks endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <param name="marketCode"></param>
+        /// <returns></returns>
+        Task<ViewModels.TopTracks> GetArtistTopTracksAsync(string artistId, string marketCode);
     }
 }

--- a/2. Managers/MusicAPI.Managers/Mapping/AlbumMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/AlbumMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class AlbumMappingProfile : Profile
+    {
+        public AlbumMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.Album, ViewModels.Album>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/Mapping/ExternalIdMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/ExternalIdMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class ExternalIdMappingProfile : Profile
+    {
+        public ExternalIdMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.ExternalId, ViewModels.ExternalId>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/Mapping/RestrictionMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/RestrictionMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class RestrictionMappingProfile : Profile
+    {
+        public RestrictionMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.Restriction, ViewModels.Restriction>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/Mapping/TopTracksMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/TopTracksMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class TopTracksMappingProfile : Profile
+    {
+        public TopTracksMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.TopTracks, ViewModels.TopTracks>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/Mapping/TrackMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/TrackMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class TrackMappingProfile : Profile
+    {
+        public TrackMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.Track, ViewModels.Track>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/MusicAPI.Managers.csproj
+++ b/2. Managers/MusicAPI.Managers/MusicAPI.Managers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/2. Managers/MusicAPI.Managers/SpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/SpotifyManager.cs
@@ -24,7 +24,7 @@ namespace MusicAPI.Managers
                 .GetCurrentUserProfileAsync(bearerToken, queryString);
 
             return mapper
-                .Map<ViewModels.UserProfile>(userProfileDto);;
+                .Map<ViewModels.UserProfile>(userProfileDto) ?? new ViewModels.UserProfile();
         }
 
         public async Task<ViewModels.SearchResult> GetSearchAsync(
@@ -51,7 +51,7 @@ namespace MusicAPI.Managers
                 .GetSearchAsync(bearerToken, queryString);
 
             return mapper
-                .Map<ViewModels.SearchResult>(searchResultDto);
+                .Map<ViewModels.SearchResult>(searchResultDto) ?? new ViewModels.SearchResult(); ;
         }
 
         public async Task<ViewModels.Artist> GetArtistAsync(string artistId)
@@ -66,7 +66,22 @@ namespace MusicAPI.Managers
                 .GetArtistAsync(bearerToken, queryString);
 
             return mapper
-                .Map<ViewModels.Artist>(artistDto);
+                .Map<ViewModels.Artist>(artistDto) ?? new ViewModels.Artist(); ;
+        }
+
+        public async Task<ViewModels.TopTracks> GetArtistTopTracksAsync(string artistId, string marketCode)
+        {
+            var bearerToken = await authorizationAccessor
+                .RequestAccessTokenAsync();
+
+            var queryString = queryEngine
+                .BuildArtistTopTracksQueryString(artistId, marketCode);
+
+            var topTracksDto = await spotifyAccessor
+                .GetTopTracksAsync(bearerToken, queryString);
+
+            return mapper
+                .Map<ViewModels.TopTracks>(topTracksDto) ?? new ViewModels.TopTracks();
         }
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/Album.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Album.cs
@@ -1,0 +1,33 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class Album
+    {
+        public string AlbumType { get; set; } = string.Empty;
+
+        public decimal TotalTracks { get; set; } = 0;
+
+        public string[] AvailableMarkets { get; set; } = [];
+
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        public string Href { get; set; } = string.Empty;
+
+        public string Id { get; set; } = string.Empty;
+
+        public Image[] Images { get; set; } = [];
+
+        public string Name { get; set; } = string.Empty;
+
+        public string ReleaseDate { get; set; } = string.Empty;
+
+        public string ReleaseDatePrecision { get; set; } = string.Empty;
+
+        public Restriction Restrictions { get; set; } = new Restriction();
+
+        public string Type { get; set; } = string.Empty;
+
+        public string Uri { get; set; } = string.Empty;
+
+        public Artist[] Artists { get; set; } = [];
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/ExternalId.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/ExternalId.cs
@@ -1,0 +1,11 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class ExternalId
+    {
+        public string InternationalStandardRecordingCode { get; set; } = string.Empty;
+
+        public string InternationalArticleNumber { get; set; } = string.Empty;
+
+        public string UniversalProductCode { get; set; } = string.Empty;
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/ExternalUrl.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/ExternalUrl.cs
@@ -2,11 +2,6 @@
 {
     public class ExternalUrl
     {
-        public ExternalUrl()
-        {
-            Spotify = string.Empty;
-        }
-
-        public string Spotify { get; set; }
+        public string Spotify { get; set; } = string.Empty;
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/Image.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Image.cs
@@ -2,17 +2,10 @@
 {
     public class Image
     {
-        public Image()
-        {
-            Url = string.Empty;
-            Height = 0;
-            Width = 0;
-        }
+        public string Url { get; set; } = string.Empty;
 
-        public string Url { get; set; }
+        public int Height { get; set; } = 0;
 
-        public int Height { get; set; }
-
-        public int Width { get; set; }
+        public int Width { get; set; } = 0;
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/Restriction.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Restriction.cs
@@ -1,0 +1,7 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class Restriction
+    {
+        public string Reason { get; set; } = string.Empty;
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/TopTracks.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/TopTracks.cs
@@ -1,0 +1,7 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class TopTracks
+    {
+        public Track[] Tracks { get; set; } = [];
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/Track.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Track.cs
@@ -1,0 +1,43 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class Track
+    {
+        public Album Album { get; set; } = new Album();
+
+        public Artist[] Artists { get; set; } = [];
+
+        public string[] AvailableMarkets { get; set; } = [];
+
+        public int DiscNumber { get; set; } = 0;
+
+        public decimal DurationInMilliseconds { get; set; } = 0;
+
+        public bool IsExplicit { get; set; }
+
+        public ExternalId ExternalIds { get; set; } = new ExternalId();
+
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        public string Href { get; set; } = string.Empty;
+
+        public string Id { get; set; } = string.Empty;
+
+        public bool IsPlayable { get; set; }
+
+        public Restriction Restrictions { get; set; } = new Restriction();
+
+        public string Name { get; set; } = string.Empty;
+
+        public decimal Popularity { get; set; } = 0;
+
+        public string? PreviewUrl { get; set; } = string.Empty;
+
+        public decimal TrackNumber { get; set; } = 0;
+
+        public string Type { get; set; } = string.Empty;
+
+        public string Uri { get; set; } = string.Empty;
+
+        public bool IsLocal { get; set; }
+    }
+}

--- a/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
@@ -32,5 +32,7 @@
         /// <param name="artistId"></param>
         /// <returns></returns>
         string BuildGetArtistQueryString(string artistId);
+
+        string BuildArtistTopTracksQueryString(string artistId, string marketCode);
     }
 }

--- a/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
@@ -33,6 +33,12 @@
         /// <returns></returns>
         string BuildGetArtistQueryString(string artistId);
 
+        /// <summary>
+        /// Responsible for building a query string that targets Spotify's Web API GET /artists/{id}/top-tracks endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <param name="marketCode"></param>
+        /// <returns></returns>
         string BuildArtistTopTracksQueryString(string artistId, string marketCode);
     }
 }

--- a/3. Engines/MusicAPI.Engines/QueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/QueryEngine.cs
@@ -48,5 +48,10 @@ namespace MusicAPI.Engines
         {
             return $"{SpotifyBaseUri}/artists/{artistId}";
         }
+
+        public string BuildArtistTopTracksQueryString(string artistId, string marketCode)
+        {
+            return $"{SpotifyBaseUri}/artists/{artistId}/top-tracks?market={marketCode}";
+        }
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Album.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Album.cs
@@ -1,0 +1,91 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class Album
+    {
+        /// <summary>
+        /// The type of the album. Allowed values are album, single, compliation.
+        /// </summary>
+        [JsonPropertyName("album_type")]
+        public string AlbumType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The number of tracks in the album.
+        /// </summary>
+        [JsonPropertyName("total_tracks")]
+        public decimal TotalTracks { get; set; } = 0;
+
+        /// <summary>
+        /// The markets in which the album is available: ISO 3166-1 alpha-2 country codes.
+        /// </summary>
+        [JsonPropertyName("available_markets")]
+        public string[] AvailableMarkets { get; set; } = [];
+
+        /// <summary>
+        /// Known external URL's for this album.
+        /// </summary>
+        [JsonPropertyName("external_urls")]
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        /// <summary>
+        /// A link to the Web API endpoint providing full details of the album.
+        /// </summary>
+        [JsonPropertyName("href")]
+        public string Href { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Spotify ID for the album.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The cover art for the album in various sizes, widest first.
+        /// </summary>
+        [JsonPropertyName("images")]
+        public Image[] Images { get; set; } = [];
+
+        /// <summary>
+        /// The name of the album. In case of an album takedown, this value may be an empty string.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The date the album was first released.
+        /// </summary>
+        [JsonPropertyName("release_date")]
+        public string ReleaseDate { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The precision with which release_date value is known. Allowed values are year, month, day.
+        /// </summary>
+        [JsonPropertyName("release_date_precision")]
+        public string ReleaseDatePrecision { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Included in the response when a content restriction is applied.
+        /// </summary>
+        [JsonPropertyName("restrictions")]
+        public Restriction Restrictions {  get; set; } = new Restriction();
+        
+        /// <summary>
+        /// The object type. Allowed value is album.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Spotify URI for the album.
+        /// </summary>
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The artists of the album. Each artist object includes a link in href to more detailed information about the artist.
+        /// </summary>
+        [JsonPropertyName("artists")]
+        public Artist[] Artists { get; set; } = []; 
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/ExternalId.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/ExternalId.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class ExternalId
+    {
+        /// <summary>
+        /// An international standard code for uniquely identifying sound recordings and music video recordings.
+        /// </summary>
+        [JsonPropertyName("isrc")]
+        public string InternationalStandardRecordingCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// A standard describing a barcode symbology and numbering system used in global trade to identify a specific retail
+        /// product type, in a specific packagin configuration, from a specific manufacturer.
+        /// </summary>
+        [JsonPropertyName("ean")]
+        public string InternationalArticleNumber { get; set; } = string.Empty;
+
+        /// <summary>
+        /// A barcode symbology that is widely used worldwide for tracking trade items in stores.
+        /// </summary>
+        [JsonPropertyName("upc")]
+        public string UniversalProductCode { get;set; } = string.Empty;
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Restriction.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Restriction.cs
@@ -1,0 +1,15 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class Restriction
+    {
+        /// <summary>
+        /// The reason for the restriction. Albums may be restricted if the content is not available in a given market,
+        /// to the user's subscription type, or when the user's account is set to not play explicit content. Allowed values
+        /// are market, product, explicit.
+        /// </summary>
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; } = string.Empty;
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/TopTracks.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/TopTracks.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class TopTracks
+    {
+        /// <summary>
+        /// An array of Track objects.
+        /// </summary>
+        [JsonPropertyName("tracks")]
+        public Track[] Tracks { get; set; } = [];
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Track.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Track.cs
@@ -1,0 +1,125 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class Track
+    {
+        /// <summary>
+        /// The album on which the track apperas. The album object includes a link in href to full information about the album.
+        /// </summary>
+        [JsonPropertyName("album")]
+        public Album Album { get; set; } = new Album();
+
+        /// <summary>
+        /// The artists who performed the track. Each artist object includes a link in href to more detailed information
+        /// about the artist.
+        /// </summary>
+        [JsonPropertyName("artists")]
+        public Artist[] Artists { get; set; } = [];
+
+        /// <summary>
+        /// A list of countries in which the track can be played, identified by their ISO 3166-1 alpha-2 code.
+        /// </summary>
+        [JsonPropertyName("available_markets")]
+        public string[] AvailableMarkets { get; set; } = [];
+
+        /// <summary>
+        /// The disc number (usually 1 unless the album consists of more than one disc.)
+        /// </summary>
+        [JsonPropertyName("disc_number")]
+        public int DiscNumber { get; set; } = 0;
+
+        /// <summary>
+        /// The track length in milliseconds.
+        /// </summary>
+        [JsonPropertyName("duration_ms")]
+        public decimal DurationInMilliseconds { get; set; } = 0;
+
+        /// <summary>
+        /// Whether or not the track has explicit lyrics (true if yes it does, false if no OR unknown).
+        /// </summary>
+        [JsonPropertyName("explicit")]
+        public bool IsExplicit { get; set; }
+
+        /// <summary>
+        /// Known external ID's for the track.
+        /// </summary>
+        [JsonPropertyName("external_ids")]
+        public ExternalId ExternalIds { get; set; } = new ExternalId();
+
+        /// <summary>
+        /// Known external URL's for this track.
+        /// </summary>
+        [JsonPropertyName("external_urls")]
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        /// <summary>
+        /// A link to the Web API endpoint providing full details of the track.
+        /// </summary>
+        [JsonPropertyName("href")]
+        public string Href { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Spotify ID for the track.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Part of the response when Track Relinking is applied. If true, the track is playable in the given
+        /// market. Otherwise false.
+        /// </summary>
+        [JsonPropertyName("is_playable")]
+        public bool IsPlayable { get; set; }
+
+        // TODO: Look more into the Linked_From object
+
+        /// <summary>
+        /// Included in the response when a content restriction is applied.
+        /// </summary>
+        [JsonPropertyName("restrictions")]
+        public Restriction Restrictions { get; set; } = new Restriction();
+
+        /// <summary>
+        /// The name of the track.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The popularity of the track. The value will be between 0 and 100, with 100 being the most popular.
+        /// </summary>
+        [JsonPropertyName("popularity")]
+        public decimal Popularity { get; set; } = 0;
+
+        /// <summary>
+        /// A link to a 30 second preview (MP3 format) of the track. Can be null.
+        /// </summary>
+        [JsonPropertyName("preview_url")]
+        public string? PreviewUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The number of the Track. If an album has several discs, the track number is the number of the specified disc.
+        /// </summary>
+        [JsonPropertyName("track_number")]
+        public decimal TrackNumber { get; set; } = 0;
+
+        /// <summary>
+        /// The object type: "Track".
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Spotify URI for the track.
+        /// </summary>
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether or not the track is from a local file.
+        /// </summary>
+        [JsonPropertyName("is_local")]
+        public bool IsLocal { get; set; }
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
@@ -27,5 +27,13 @@ namespace MusicAPI.Accessors.Interfaces
         /// <param name="queryString"></param>
         /// <returns></returns>
         Task<Artist> GetArtistAsync(string bearerToken, string queryString);
+
+        /// <summary>
+        /// Communicates with Spotify's Web API to retreive the Top Tracks for a given artist.
+        /// </summary>
+        /// <param name="bearerToken"></param>
+        /// <param name="queryString"></param>
+        /// <returns></returns>
+        Task<TopTracks> GetTopTracksAsync(string bearerToken, string queryString);
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -1,4 +1,4 @@
-﻿ using MusicAPI.Accessors.DataTransferObjects;
+﻿using MusicAPI.Accessors.DataTransferObjects;
 using MusicAPI.Accessors.Interfaces;
 using System.Net.Http.Headers;
 using System.Text.Json;

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -70,6 +70,27 @@ namespace MusicAPI.Accessors
             throw new HttpRequestException($"Unable to retrieve Artist data using the request {queryString}");
         }
 
+        public async Task<TopTracks> GetTopTracksAsync(string bearerToken, string queryString)
+        {
+            ValidateParameters(bearerToken, queryString);
+
+            var response = await ExecuteGetRequest(bearerToken, queryString);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var responseContent = await response
+                    .Content
+                    .ReadAsStringAsync();
+
+                var topTracks =  JsonSerializer
+                    .Deserialize<TopTracks>(responseContent);
+
+                return topTracks ?? new TopTracks();
+            }
+
+            throw new HttpRequestException($"Unable to retrieve Artist Top Tracks using the request {queryString}");
+        }
+
         private async Task<HttpResponseMessage> ExecuteGetRequest(string bearerToken, string queryString)
         {
             var httpClient = SetupHttpClient(bearerToken);

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -1,4 +1,4 @@
-﻿using MusicAPI.Accessors.DataTransferObjects;
+﻿ using MusicAPI.Accessors.DataTransferObjects;
 using MusicAPI.Accessors.Interfaces;
 using System.Net.Http.Headers;
 using System.Text.Json;

--- a/7. Unit Tests/MusicAPI.Accessors.Tests/SpotifyAccessorTests.cs
+++ b/7. Unit Tests/MusicAPI.Accessors.Tests/SpotifyAccessorTests.cs
@@ -301,5 +301,105 @@
             // Assert
             Assert.That(result.Id, Is.EqualTo(expectedArtistId));
         }
+
+        [Test]
+        public void GetTopTracksAsync_EmptyBearerToken_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+
+            var spotifyAccesor = new SpotifyAccessor(mockHttpClientFactory.Object);
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await spotifyAccesor.GetTopTracksAsync(string.Empty, string.Empty));
+        }
+
+        [Test]
+        public void GetTopTracksAsync_EmptyQueryString_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+
+            var spotifyAccessor = new SpotifyAccessor(mockHttpClientFactory.Object);
+
+            // Act & Assert
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await spotifyAccessor.GetTopTracksAsync("bearerToken", string.Empty));
+        }
+
+        [Test]
+        public void GetTopTracksAsync_UnsuccessfulStatusCode_ShouldThrowHttpRequestException()
+        {
+            // Arrange
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.BadRequest
+                });
+
+            mockHttpClientFactory
+                .Setup(httpClientFactory => httpClientFactory.CreateClient(string.Empty))
+                .Returns(new HttpClient(mockHttpMessageHandler.Object));
+
+            var spotifyAccessor = new SpotifyAccessor(mockHttpClientFactory.Object);
+
+            // Act & Assert
+            Assert.ThrowsAsync<HttpRequestException>(async () =>
+                await spotifyAccessor.GetTopTracksAsync("bearer", "http://localhost"));
+        }
+
+        [Test]
+        public async Task GetTopTracksAsync_SuccessfulStatusCode_ShouldReturnTopTracks()
+        {
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            const string expectedTrackHref = "Expected Track Href";
+
+            var expectedTopTracks = new TopTracks
+            {
+                Tracks =
+                [
+                    new Track
+                    {
+                        Href = expectedTrackHref
+                    }
+                ]
+            };
+
+            mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.OK,
+                    Content = new StringContent(JsonSerializer.Serialize(expectedTopTracks))
+                });
+
+            mockHttpClientFactory
+                .Setup(httpClientFactory => httpClientFactory.CreateClient(string.Empty))
+                .Returns(new HttpClient(mockHttpMessageHandler.Object));
+
+            var spotifyAccessor = new SpotifyAccessor(mockHttpClientFactory.Object);
+
+            // Act
+            var topTracks = await spotifyAccessor
+                .GetTopTracksAsync("bearer", "http://localhost");
+
+            // Assert
+            Assert.That(topTracks.Tracks[0].Href, Is.EqualTo(expectedTrackHref));
+        }
     }
 }

--- a/7. Unit Tests/MusicAPI.Accessors.Tests/SpotifyAccessorTests.cs
+++ b/7. Unit Tests/MusicAPI.Accessors.Tests/SpotifyAccessorTests.cs
@@ -360,6 +360,7 @@
         [Test]
         public async Task GetTopTracksAsync_SuccessfulStatusCode_ShouldReturnTopTracks()
         {
+            // Arrange
             var mockHttpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
 

--- a/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
+++ b/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
@@ -82,5 +82,21 @@
 
             Assert.That(queryString, Is.EqualTo(expectedQueryString));
         }
+
+        [Test]
+        public void BuildArtistTopTracksQueryString_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildArtistTopTracksQueryString("artistId", "marketCode");
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/artistId/top-tracks?market=marketCode";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
     }
 }

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/AlbumMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/AlbumMappingProfileTests.cs
@@ -1,0 +1,121 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class AlbumMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(AlbumMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(ImageMappingProfile));
+                configuration.AddProfile(typeof(RestrictionMappingProfile));
+                configuration.AddProfile(typeof(ArtistMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void AlbumMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void Album_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedAlbumType = "Expected Album Type";
+            const decimal expectedTotalTracks = 10;
+            const string expectedAvailableMarket = "ES";
+            const string expectedExternalUrl = "Spotify";
+            const string expectedAlbumHref = "Album Href";
+            const string expectedAlbumId = "Album ID";
+            const string expectedImageUrl = "Image Url";
+            const int expectedImageHeight = 100;
+            const int expectedImageWidth = 200;
+            const string expectedAlbumName = "Album Name";
+            const string expectedReleaseDate = "Release Date";
+            const string expectedReleaseDatePrecision = "Release Date Precision";
+            const string expectedRestrictionReason = "Restriction Reason";
+            const string expectedType = "Album Type";
+            const string expectedUri = "Album Uri";
+            const string expectedArtistId = "Artist Id";
+
+
+            var albumDataTransferObject = new Accessors.DataTransferObjects.Album
+            {
+                AlbumType = expectedAlbumType,
+                TotalTracks = expectedTotalTracks,
+                AvailableMarkets =
+                [
+                    expectedAvailableMarket
+                ],
+                ExternalUrls = new Accessors.DataTransferObjects.ExternalUrl
+                {
+                    Spotify = expectedExternalUrl
+                },
+                Href = expectedAlbumHref,
+                Id = expectedAlbumId,
+                Images =
+                [
+                    new Accessors.DataTransferObjects.Image
+                    {
+                        Url = expectedImageUrl,
+                        Height = expectedImageHeight,
+                        Width = expectedImageWidth
+                    }
+                ],
+                Name = expectedAlbumName,
+                ReleaseDate = expectedReleaseDate,
+                ReleaseDatePrecision = expectedReleaseDatePrecision,
+                Restrictions = new Accessors.DataTransferObjects.Restriction
+                {
+                    Reason = expectedRestrictionReason
+                },
+                Type = expectedType,
+                Uri = expectedUri,
+                Artists =
+                [
+                    new Accessors.DataTransferObjects.Artist
+                    {
+                        Id = expectedArtistId
+                    }
+                ]
+            };
+
+            // Act
+            var albumViewModel = Mapper.Map<ViewModels.Album>(albumDataTransferObject);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(albumViewModel.AlbumType, Is.EqualTo(expectedAlbumType));
+                Assert.That(albumViewModel.TotalTracks, Is.EqualTo(expectedTotalTracks));
+                Assert.That(albumViewModel.AvailableMarkets[0], Is.EqualTo(expectedAvailableMarket));
+                Assert.That(albumViewModel.ExternalUrls.Spotify, Is.EqualTo(expectedExternalUrl));
+                Assert.That(albumViewModel.Href, Is.EqualTo(expectedAlbumHref));
+                Assert.That(albumViewModel.Id, Is.EqualTo(expectedAlbumId));
+                Assert.That(albumViewModel.Images[0].Url, Is.EqualTo(expectedImageUrl));
+                Assert.That(albumViewModel.Images[0].Height, Is.EqualTo(expectedImageHeight));
+                Assert.That(albumViewModel.Images[0].Width, Is.EqualTo(expectedImageWidth));
+                Assert.That(albumViewModel.Name, Is.EqualTo(expectedAlbumName));
+                Assert.That(albumViewModel.ReleaseDate, Is.EqualTo(expectedReleaseDate));
+                Assert.That(albumViewModel.ReleaseDatePrecision, Is.EqualTo(expectedReleaseDatePrecision));
+                Assert.That(albumViewModel.Restrictions.Reason, Is.EqualTo(expectedRestrictionReason));
+                Assert.That(albumViewModel.Type, Is.EqualTo(expectedType));
+                Assert.That(albumViewModel.Uri, Is.EqualTo(expectedUri));
+                Assert.That(albumViewModel.Artists[0].Id, Is.EqualTo(expectedArtistId));
+            });
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ArtistMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ArtistMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.Tests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class ArtistMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ArtistsMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ArtistsMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.Tests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class ArtistsMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ExplicitContentFilterMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ExplicitContentFilterMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.UnitTests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class ExplicitContentFilterMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ExternalIdMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ExternalIdMappingProfileTests.cs
@@ -1,0 +1,55 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class ExternalIdMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(ExternalIdMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void ExternalIdMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void ExternalId_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedInternationalArticleNumber = "IAN";
+            const string expectedInternationalStandardRecordingCode = "ISRC";
+            const string expectedUniversalProductCode = "UPC";
+
+            var externalIdDataTransferObject = new Accessors.DataTransferObjects.ExternalId
+            {
+                InternationalArticleNumber = expectedInternationalArticleNumber,
+                InternationalStandardRecordingCode = expectedInternationalStandardRecordingCode,
+                UniversalProductCode = expectedUniversalProductCode
+            };
+
+            // Act
+            var externalIdViewModel = Mapper.Map<ViewModels.ExternalId>(externalIdDataTransferObject);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(externalIdViewModel.InternationalArticleNumber, Is.EqualTo(expectedInternationalArticleNumber));
+                Assert.That(externalIdViewModel.InternationalStandardRecordingCode, Is.EqualTo(expectedInternationalStandardRecordingCode));
+                Assert.That(externalIdViewModel.UniversalProductCode, Is.EqualTo(expectedUniversalProductCode));
+            });
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ExternalUrlMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ExternalUrlMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.UnitTests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class ExternalUrlMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/FollowersMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/FollowersMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.UnitTests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class FollowersMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ImageMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/ImageMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.UnitTests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class ImageMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/RestrictionMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/RestrictionMappingProfileTests.cs
@@ -1,0 +1,46 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class RestrictionMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(RestrictionMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void RestrictionMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void Restriction_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedReason = "Restriction Reason";
+
+            var restrictionDataTransferObject = new Accessors.DataTransferObjects.Restriction
+            {
+                Reason = expectedReason
+            };
+
+            // Act
+            var restrictionViewModel = Mapper.Map<ViewModels.Restriction>(restrictionDataTransferObject);
+
+            // Assert
+            Assert.That(restrictionViewModel.Reason, Is.EqualTo(expectedReason));
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/SearchResultMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/SearchResultMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.Tests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class SearchResultMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TopTracksMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TopTracksMappingProfileTests.cs
@@ -49,7 +49,7 @@
             var topTracksViewModel = Mapper.Map<ViewModels.TopTracks>(topTracksDataTransferObject);
 
             // Assert
-            Assert.IsNotNull(topTracksViewModel.Tracks);
+            Assert.That(topTracksViewModel.Tracks, Is.Not.Null);
         }
     }
 }

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TopTracksMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TopTracksMappingProfileTests.cs
@@ -1,0 +1,55 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class TopTracksMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(TopTracksMappingProfile));
+                configuration.AddProfile(typeof(TrackMappingProfile));
+                configuration.AddProfile(typeof(AlbumMappingProfile));
+                configuration.AddProfile(typeof(ArtistMappingProfile));
+                configuration.AddProfile(typeof(ExternalIdMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(RestrictionMappingProfile));
+                configuration.AddProfile(typeof(ImageMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void TopTracksMappingProfile_AsserConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void TopTracks_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            var topTracksDataTransferObject = new Accessors.DataTransferObjects.TopTracks
+            {
+                Tracks =
+                [
+                    new Accessors.DataTransferObjects.Track()
+                ]
+            };
+
+            // Act
+            var topTracksViewModel = Mapper.Map<ViewModels.TopTracks>(topTracksDataTransferObject);
+
+            // Assert
+            Assert.IsNotNull(topTracksViewModel.Tracks);
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TrackMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TrackMappingProfileTests.cs
@@ -83,18 +83,18 @@
             // Assert
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(trackViewModel.Album);
-                Assert.IsNotNull(trackViewModel.Artists);
+                Assert.That(trackViewModel.Album, Is.Not.Null);
+                Assert.That(trackViewModel.Artists, Is.Not.Null);
                 Assert.That(trackViewModel.AvailableMarkets[0], Is.EqualTo(expectedAvailableMarket));
                 Assert.That(trackViewModel.DiscNumber, Is.EqualTo(expectedDiscNumber));
                 Assert.That(trackViewModel.DurationInMilliseconds, Is.EqualTo(expectedDurationInMilliseconds));
                 Assert.That(trackViewModel.IsExplicit, Is.True);
-                Assert.IsNotNull(trackViewModel.ExternalIds);
-                Assert.IsNotNull(trackViewModel.ExternalUrls);
+                Assert.That(trackViewModel.ExternalIds, Is.Not.Null);
+                Assert.That(trackViewModel.ExternalUrls, Is.Not.Null);
                 Assert.That(trackViewModel.Href, Is.EqualTo(expectedTrackHref));
                 Assert.That(trackViewModel.Id, Is.EqualTo(expectedTrackId));
                 Assert.That(trackViewModel.IsPlayable, Is.True);
-                Assert.IsNotNull(trackViewModel.Restrictions);
+                Assert.That(trackViewModel.Restrictions, Is.Not.Null);
                 Assert.That(trackViewModel.Name, Is.EqualTo(expectedTrackName));
                 Assert.That(trackViewModel.Popularity, Is.EqualTo(expectedPopularity));
                 Assert.That(trackViewModel.PreviewUrl, Is.EqualTo(expectedPreviewUrl));

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TrackMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/TrackMappingProfileTests.cs
@@ -1,0 +1,108 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class TrackMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(TrackMappingProfile));
+                configuration.AddProfile(typeof(AlbumMappingProfile));
+                configuration.AddProfile(typeof(ArtistMappingProfile));
+                configuration.AddProfile(typeof(ExternalIdMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(RestrictionMappingProfile));
+                configuration.AddProfile(typeof(ImageMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void TrackMappingProfile_AsserConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void Track_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedAvailableMarket = "ES";
+            const int expectedDiscNumber = 1;
+            const decimal expectedDurationInMilliseconds = 1000;
+            const string expectedTrackHref = "Track Href";
+            const string expectedTrackId = "Track ID";
+            const string expectedTrackName = "Track Name";
+            const decimal expectedPopularity = 100;
+            const string expectedPreviewUrl = "Preview Url";
+            const decimal expectedTrackNumber = 1;
+            const string expectedTrackType = "Track Type";
+            const string expectedTrackUri = "Track Uri";
+
+            var trackDataTransferObject = new Accessors.DataTransferObjects.Track
+            {
+                Album = new Accessors.DataTransferObjects.Album(),
+                Artists =
+                [
+                    new Accessors.DataTransferObjects.Artist()
+                ],
+                AvailableMarkets =
+                [
+                    expectedAvailableMarket
+                ],
+                DiscNumber = expectedDiscNumber,
+                DurationInMilliseconds = expectedDurationInMilliseconds,
+                IsExplicit = true,
+                ExternalIds = new Accessors.DataTransferObjects.ExternalId(),
+                ExternalUrls = new Accessors.DataTransferObjects.ExternalUrl(),
+                Href = expectedTrackHref,
+                Id = expectedTrackId,
+                IsPlayable = true,
+                Restrictions = new Accessors.DataTransferObjects.Restriction(),
+                Name = expectedTrackName,
+                Popularity = expectedPopularity,
+                PreviewUrl = expectedPreviewUrl,
+                TrackNumber = expectedTrackNumber,
+                Type = expectedTrackType,
+                Uri = expectedTrackUri,
+                IsLocal = true
+            };
+
+            // Act
+            var trackViewModel = Mapper.Map<ViewModels.Track>(trackDataTransferObject);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(trackViewModel.Album);
+                Assert.IsNotNull(trackViewModel.Artists);
+                Assert.That(trackViewModel.AvailableMarkets[0], Is.EqualTo(expectedAvailableMarket));
+                Assert.That(trackViewModel.DiscNumber, Is.EqualTo(expectedDiscNumber));
+                Assert.That(trackViewModel.DurationInMilliseconds, Is.EqualTo(expectedDurationInMilliseconds));
+                Assert.That(trackViewModel.IsExplicit, Is.True);
+                Assert.IsNotNull(trackViewModel.ExternalIds);
+                Assert.IsNotNull(trackViewModel.ExternalUrls);
+                Assert.That(trackViewModel.Href, Is.EqualTo(expectedTrackHref));
+                Assert.That(trackViewModel.Id, Is.EqualTo(expectedTrackId));
+                Assert.That(trackViewModel.IsPlayable, Is.True);
+                Assert.IsNotNull(trackViewModel.Restrictions);
+                Assert.That(trackViewModel.Name, Is.EqualTo(expectedTrackName));
+                Assert.That(trackViewModel.Popularity, Is.EqualTo(expectedPopularity));
+                Assert.That(trackViewModel.PreviewUrl, Is.EqualTo(expectedPreviewUrl));
+                Assert.That(trackViewModel.TrackNumber, Is.EqualTo(expectedTrackNumber));
+                Assert.That(trackViewModel.Type, Is.EqualTo(expectedTrackType));
+                Assert.That(trackViewModel.Uri, Is.EqualTo(expectedTrackUri));
+                Assert.That(trackViewModel.IsLocal, Is.True);
+            });
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/UserProfileMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/UserProfileMappingProfileTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MusicAPI.Managers.UnitTests.Mapping
 {
+#pragma warning disable CS8602
     [TestFixture]
     [ExcludeFromCodeCoverage]
     public class UserProfileMappingProfileTests

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
@@ -144,6 +144,50 @@ namespace MusicAPI.Managers.Tests
                     Times.Once);
         }
 
+        [Test]
+        public async Task GetArtistTopTracksAsync_ShouldReturnTopTracks()
+        {
+            // Arrange
+            var mockAuthorizationAccessor = GetMockAuthorizationAccessor();
+
+            var mockQueryEngine = new Mock<IQueryEngine>(MockBehavior.Strict);
+            mockQueryEngine
+                .Setup(queryEngine => queryEngine.BuildArtistTopTracksQueryString(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Returns("http://localhost");
+
+            var mockSpotifyAccessor = new Mock<ISpotifyAccessor>(MockBehavior.Strict);
+            mockSpotifyAccessor
+                .Setup(spotifyAccessor => spotifyAccessor.GetTopTracksAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new Accessors.DataTransferObjects.TopTracks());
+
+            var mockMapper = new Mock<IMapper>(MockBehavior.Strict);
+            mockMapper
+                .Setup(mapper => mapper.Map<ViewModels.TopTracks>(It.IsAny<Accessors.DataTransferObjects.TopTracks>()))
+                .Returns(new ViewModels.TopTracks());
+
+            var spotifyManager = new SpotifyManager(
+                mockAuthorizationAccessor.Object,
+                mockMapper.Object,
+                mockSpotifyAccessor.Object,
+                mockQueryEngine.Object);
+
+            // Act
+            var topTracks = await spotifyManager
+                .GetArtistTopTracksAsync("artistId", "marketCode");
+
+            // Assert
+            mockSpotifyAccessor
+                .Verify(
+                    spotifyAccessor => spotifyAccessor.GetTopTracksAsync(
+                        It.Is<string>(bearerToken => bearerToken.Equals("Bearer Token")),
+                        It.Is<string>(queryString => queryString.Equals("http://localhost"))),
+                    Times.Once());
+        }
+
         private static Mock<IAuthorizationAccessor> GetMockAuthorizationAccessor()
         {
             var mockAuthorizationAccessor = new Mock<IAuthorizationAccessor>(MockBehavior.Strict);


### PR DESCRIPTION
This PR adds the following updates
- Adds new Endpoint onto ArtistController to get top tracks by artist for a specified market
- Updates routing for endpoints to use Controller in query 
- Adds Accessor/Manager/Engine methods to facilitate getting Artist top tracks
- Unit Test coverage for new endpoints.