### PR TITLE
Implement GET Artist Albums endpoint

### DIFF
--- a/1. Clients/MusicAPI/Controllers/ArtistController.cs
+++ b/1. Clients/MusicAPI/Controllers/ArtistController.cs
@@ -70,8 +70,12 @@ namespace MusicAPI.Controllers
         /// <summary>
         /// Gets Spotify catalog information about an artist's top tracks by country.
         /// </summary>
-        /// <param name="artistId"></param>
-        /// <param name="marketCode"></param>
+        /// <param name="artistId">
+        ///     The Spotify ID of the artist.
+        /// </param>
+        /// <param name="marketCode">
+        ///     An ISO 3166-1 alpha-2 country code.
+        /// </param>
         /// <returns></returns>
         [HttpGet]
         [Route("topTracks")]
@@ -84,6 +88,42 @@ namespace MusicAPI.Controllers
                 .GetArtistTopTracksAsync(artistId, marketCode);
 
             return Ok(topTracks);
+        }
+
+        /// <summary>
+        /// Gets Spotify catalog information about an artist's albums.
+        /// </summary>
+        /// <param name="artistId">
+        ///     The Spotify ID of the artist.
+        /// </param>
+        /// <param name="marketCode">
+        ///     An ISO 3166-1 alpha-2 country code.
+        /// </param>
+        /// <param name="includeGroups">
+        ///     A comma-separated list of keywords that will be used to filter the response. if not supplied, all album types will
+        ///     be returned. Valid values are album, single, appears_on, compilation. For example: include_groups=album,single
+        /// </param>
+        /// <param name="limit">
+        ///     The maximum number of items to return. Default: 20. Minimum: 1, Maximum: 50.
+        /// </param>
+        /// <param name="offset">
+        ///     The index of the first item to return. Default: 0 (the first item). Use with limit to get the next set of items.
+        /// </param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("albums")]
+        [Produces(typeof(OkObjectResult))]
+        public async Task<IActionResult> GetAlbumsAsync(
+            [Required] string artistId,
+            [Required] string marketCode,
+            string? includeGroups = null,
+            int? limit = null,
+            int? offset = null)
+        {
+            var albums = await spotifyManager
+                .GetAlbumsAsync(artistId, marketCode, includeGroups, limit, offset);
+
+            return Ok(albums);
         }
     }
 }

--- a/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
@@ -44,5 +44,22 @@ namespace MusicAPI.Managers.Interfaces
         /// <param name="marketCode"></param>
         /// <returns></returns>
         Task<ViewModels.TopTracks> GetArtistTopTracksAsync(string artistId, string marketCode);
+
+        /// <summary>
+        /// Manager method for directing traffic to retrieve Albums for a given
+        /// Artist using Spotify's GET /artist/{id}/albums endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <param name="marketCode"></param>
+        /// <param name="includeGroups"></param>
+        /// <param name="limit"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        Task<ViewModels.Albums> GetAlbumsAsync(
+            string artistId,
+            string marketCode,
+            string? includeGroups = "",
+            int? limit = 20,
+            int? offset = 0);
     }
 }

--- a/2. Managers/MusicAPI.Managers/Mapping/AlbumsMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/AlbumsMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class AlbumsMappingProfile : Profile
+    {
+        public AlbumsMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.Albums, ViewModels.Albums>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/SpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/SpotifyManager.cs
@@ -83,5 +83,30 @@ namespace MusicAPI.Managers
             return mapper
                 .Map<ViewModels.TopTracks>(topTracksDto) ?? new ViewModels.TopTracks();
         }
+
+        public async Task<ViewModels.Albums> GetAlbumsAsync(
+            string artistId,
+            string marketCode,
+            string? includeGroups = "",
+            int? limit = 20,
+            int? offset = 0)
+        {
+            var bearerToken = await authorizationAccessor
+                .RequestAccessTokenAsync();
+
+            var queryString = queryEngine
+                .BuildArtistAlbumsQueryString(
+                    artistId, 
+                    marketCode, 
+                    includeGroups, 
+                    limit, 
+                    offset);
+
+            var albums = await spotifyAccessor
+                .GetArtistAlbumsAsync(bearerToken, queryString);
+
+            return mapper
+                .Map<ViewModels.Albums>(albums) ?? new ViewModels.Albums();
+        }
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/Albums.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Albums.cs
@@ -14,6 +14,6 @@
 
         public decimal Total { get; set; } = 0;
 
-        public Album[] Items { get; set; }
+        public Album[] Items { get; set; } = [];
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/Albums.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Albums.cs
@@ -1,0 +1,19 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class Albums
+    {
+        public string Href { get; set; } = string.Empty;
+
+        public decimal Limit { get; set; } = 0;
+
+        public string Next { get; set; } = string.Empty;
+
+        public decimal Offset { get; set; } = 0;
+
+        public string Previous { get; set; } = string.Empty;
+
+        public decimal Total { get; set; } = 0;
+
+        public Album[] Items { get; set; }
+    }
+}

--- a/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
@@ -40,5 +40,21 @@
         /// <param name="marketCode"></param>
         /// <returns></returns>
         string BuildArtistTopTracksQueryString(string artistId, string marketCode);
+
+        /// <summary>
+        /// Responsible for building a query string that targets Spotify's Web API GET /artists/{id}/albums endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <param name="marketCode"></param>
+        /// <param name="includeGroups"></param>
+        /// <param name="limit"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        string BuildArtistAlbumsQueryString(
+            string artistId, 
+            string marketCode, 
+            string? includeGroups, 
+            int? limit, 
+            int? offset);
     }
 }

--- a/3. Engines/MusicAPI.Engines/QueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/QueryEngine.cs
@@ -53,5 +53,32 @@ namespace MusicAPI.Engines
         {
             return $"{SpotifyBaseUri}/artists/{artistId}/top-tracks?market={marketCode}";
         }
+
+        public string BuildArtistAlbumsQueryString(
+            string artistId,
+            string marketCode,
+            string? includeGroups,
+            int? limit,
+            int? offset)
+        {
+            var requestString = $"{SpotifyBaseUri}/artists/{artistId}/albums?market={marketCode}";
+
+            if (!string.IsNullOrWhiteSpace(includeGroups))
+            {
+                requestString += $"&include_groups={includeGroups}";
+            }
+
+            if (limit != null)
+            {
+                requestString += $"&limit={limit}";
+            }
+
+            if (offset != null)
+            {
+                requestString += $"&offset={offset}";
+            }
+
+            return requestString;
+        }
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Albums.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Albums.cs
@@ -44,6 +44,6 @@ namespace MusicAPI.Accessors.DataTransferObjects
         /// Array of Albums objects.
         /// </summary>
         [JsonPropertyName("items")]
-        public Album[] Items { get; set; }
+        public Album[] Items { get; set; } = [];
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Albums.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Albums.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class Albums
+    {
+        /// <summary>
+        /// A link to the Web API endpoint returning the full result of the request.
+        /// </summary>
+        [JsonPropertyName("href")]
+        public string Href { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The maximum number of items in the reponse (as set in the query or by default).
+        /// </summary>
+        [JsonPropertyName("limit")]
+        public decimal Limit { get; set; } = 0;
+
+        /// <summary>
+        /// URL to the next page of items. (null if none)
+        /// </summary>
+        [JsonPropertyName("next")]
+        public string Next { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The offset of the items returned (as set in the query or by default).
+        /// </summary>
+        [JsonPropertyName("offset")]
+        public decimal Offset { get; set; } = 0;
+
+        /// <summary>
+        /// URL to the previous page of items (null if none).
+        /// </summary>
+        [JsonPropertyName("previous")]
+        public string Previous { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The total number of items available to return.
+        /// </summary>
+        [JsonPropertyName("total")]
+        public decimal Total { get; set; } = 0;
+
+        /// <summary>
+        /// Array of Albums objects.
+        /// </summary>
+        [JsonPropertyName("items")]
+        public Album[] Items { get; set; }
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
@@ -35,5 +35,13 @@ namespace MusicAPI.Accessors.Interfaces
         /// <param name="queryString"></param>
         /// <returns></returns>
         Task<TopTracks> GetTopTracksAsync(string bearerToken, string queryString);
+
+        /// <summary>
+        /// Communicates with Spotify's Web API to retrieve Albums for a given artist.
+        /// </summary>
+        /// <param name="bearerToken"></param>
+        /// <param name="queryString"></param>
+        /// <returns></returns>
+        Task<Albums> GetArtistAlbumsAsync(string bearerToken, string queryString);
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -91,6 +91,27 @@ namespace MusicAPI.Accessors
             throw new HttpRequestException($"Unable to retrieve Artist Top Tracks using the request {queryString}");
         }
 
+        public async Task<Albums> GetArtistAlbumsAsync(string bearerToken, string queryString)
+        {
+            ValidateParameters(bearerToken, queryString);
+
+            var response = await ExecuteGetRequest(bearerToken, queryString);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var responseContent = await response
+                    .Content
+                    .ReadAsStringAsync();
+
+                var albums = JsonSerializer
+                    .Deserialize<Albums>(responseContent);
+
+                return albums ?? new Albums();
+            }
+
+            throw new HttpRequestException($"Unable to retrieve Artist Albums using the request {queryString}");
+        }
+
         private async Task<HttpResponseMessage> ExecuteGetRequest(string bearerToken, string queryString)
         {
             var httpClient = SetupHttpClient(bearerToken);

--- a/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
+++ b/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
@@ -98,5 +98,85 @@
 
             Assert.That(queryString, Is.EqualTo(expectedQueryString));
         }
+
+        [Test]
+        public void BuildArtistAlbumsQueryAString_RequiredParametersOnly_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildArtistAlbumsQueryString("artistId", "marketCode", null, null, null);
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/artistId/albums?market=marketCode";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
+
+        [Test]
+        public void BuildArtistAlbumsQueryString_IncludeGroups_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildArtistAlbumsQueryString("artistId", "marketCode", "includeGroups", null, null);
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/artistId/albums?market=marketCode&include_groups=includeGroups";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
+
+        [Test]
+        public void BuildArtistAlbumsQueryString_Limit_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildArtistAlbumsQueryString("artistId", "marketCode", null, 10, null);
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/artistId/albums?market=marketCode&limit=10";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
+
+        [Test]
+        public void BuildArtistAlbumsQueryString_Offset_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildArtistAlbumsQueryString("artistId", "marketCode", null, null, 1);
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/artistId/albums?market=marketCode&offset=1";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
+
+        [Test]
+        public void BuildArtistAlbumsQueryString_AllParameters_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildArtistAlbumsQueryString("artistId", "marketCode", "includeGroups", 10, 1);
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/artistId/albums?market=marketCode&include_groups=includeGroups&limit=10&offset=1";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
     }
 }

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/AlbumsMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/AlbumsMappingProfileTests.cs
@@ -1,0 +1,75 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class AlbumsMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(AlbumsMappingProfile));
+                configuration.AddProfile(typeof(AlbumMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(ImageMappingProfile));
+                configuration.AddProfile(typeof(RestrictionMappingProfile));
+                configuration.AddProfile(typeof(ArtistMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void AlbumsMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void Albums_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedHref = "Albums Href";
+            const decimal expectedLimit = 100;
+            const string expectedNext = "Albums Next";
+            const decimal expectedOffset = 10;
+            const string expectedPrevious = "Albums Previous";
+            const decimal expectedTotal = 1;
+
+            var albumsDataTransferObject = new Accessors.DataTransferObjects.Albums
+            {
+                Href = expectedHref,
+                Limit = expectedLimit,
+                Next = expectedNext,
+                Offset = expectedOffset,
+                Previous = expectedPrevious,
+                Total = expectedTotal,
+                Items =
+                [
+                    new Accessors.DataTransferObjects.Album()
+                ]
+            };
+
+            // Act
+            var albumsViewModel = Mapper.Map<ViewModels.Albums>(albumsDataTransferObject);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(albumsViewModel.Href, Is.EqualTo(expectedHref));
+                Assert.That(albumsViewModel.Limit, Is.EqualTo(expectedLimit));
+                Assert.That(albumsViewModel.Next, Is.EqualTo(expectedNext));
+                Assert.That(albumsViewModel.Offset, Is.EqualTo(expectedOffset));
+                Assert.That(albumsViewModel.Previous, Is.EqualTo(expectedPrevious));
+                Assert.That(albumsViewModel.Total, Is.EqualTo(expectedTotal));
+                Assert.That(albumsViewModel.Items, Is.Not.Null);
+            });
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
@@ -188,6 +188,53 @@ namespace MusicAPI.Managers.Tests
                     Times.Once());
         }
 
+        [Test]
+        public async Task GetAlbumsAsync_ShouldReturnAlbums()
+        {
+            // Arrange
+            var mockAuthorizationAccessor = GetMockAuthorizationAccessor();
+
+            var mockQueryEngine = new Mock<IQueryEngine>(MockBehavior.Strict);
+            mockQueryEngine
+                .Setup(queryEngine => queryEngine.BuildArtistAlbumsQueryString(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<int?>()))
+                .Returns("http://localhost");
+
+            var mockSpotifyAccessor = new Mock<ISpotifyAccessor>(MockBehavior.Strict);
+            mockSpotifyAccessor
+                .Setup(spotifyAccessor => spotifyAccessor.GetArtistAlbumsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new Accessors.DataTransferObjects.Albums());
+
+            var mockMapper = new Mock<IMapper>(MockBehavior.Strict);
+            mockMapper
+                .Setup(mapper => mapper.Map<ViewModels.Albums>(It.IsAny<Accessors.DataTransferObjects.Albums>()))
+                .Returns(new ViewModels.Albums());
+
+            var spotifyManager = new SpotifyManager(
+                mockAuthorizationAccessor.Object,
+                mockMapper.Object,
+                mockSpotifyAccessor.Object,
+                mockQueryEngine.Object);
+
+            // Act
+            var albums = await spotifyManager
+                .GetAlbumsAsync("artistId", "marketCode");
+
+            // Assert
+            mockSpotifyAccessor
+                .Verify(
+                    spotifyAccessor => spotifyAccessor.GetArtistAlbumsAsync(
+                        It.Is<string>(bearerToken => bearerToken.Equals("Bearer Token")),
+                        It.Is<string>(queryString => queryString.Equals("http://localhost"))),
+                    Times.Once());
+        }
+
         private static Mock<IAuthorizationAccessor> GetMockAuthorizationAccessor()
         {
             var mockAuthorizationAccessor = new Mock<IAuthorizationAccessor>(MockBehavior.Strict);


### PR DESCRIPTION
This PR includes the following changes'
- Adds endpoint to ArtistController that supports retrieving Albums for a given Artist.
- Manager/Accessor/Engine level methods that facilitate calling Spotify's Web API to retrieve artist albums
- Unit Test coverage on the respective layers