### PR TITLE
 Implement GetRelatedArtistsAsync endpoint

### DIFF
--- a/1. Clients/MusicAPI/Controllers/ArtistController.cs
+++ b/1. Clients/MusicAPI/Controllers/ArtistController.cs
@@ -125,5 +125,24 @@ namespace MusicAPI.Controllers
 
             return Ok(albums);
         }
+
+        /// <summary>
+        /// Get Spotify Catalog information about artists similar to a given artist. Similarity is based on the analysis of the Spotify
+        /// community's listening history.
+        /// </summary>
+        /// <param name="artistId">
+        ///     The Spotify ID of the artist
+        /// </param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("relatedArtists")]
+        [Produces(typeof(OkObjectResult))]
+        public async Task<IActionResult> GetRelatedArtistsAsync([Required] string artistId)
+        {
+            var relatedArtists = await spotifyManager
+                .GetRelatedArtistsAsync(artistId);
+
+            return Ok(relatedArtists);
+        }
     }
 }

--- a/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/Interfaces/ISpotifyManager.cs
@@ -61,5 +61,13 @@ namespace MusicAPI.Managers.Interfaces
             string? includeGroups = "",
             int? limit = 20,
             int? offset = 0);
+
+        /// <summary>
+        /// Manager method for directing traffic to retrieve related Artists for a given
+        /// artist using Spotify's GET /artists/{id}/related-artist endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <returns></returns>
+        Task<ViewModels.RelatedArtists> GetRelatedArtistsAsync(string artistId);
     }
 }

--- a/2. Managers/MusicAPI.Managers/Mapping/RelatedArtistsMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/RelatedArtistsMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class RelatedArtistsMappingProfile : Profile
+    {
+        public RelatedArtistsMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.RelatedArtists, ViewModels.RelatedArtists>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/SpotifyManager.cs
+++ b/2. Managers/MusicAPI.Managers/SpotifyManager.cs
@@ -108,5 +108,20 @@ namespace MusicAPI.Managers
             return mapper
                 .Map<ViewModels.Albums>(albums) ?? new ViewModels.Albums();
         }
+
+        public async Task<ViewModels.RelatedArtists> GetRelatedArtistsAsync(string artistId)
+        {
+            var bearerToken = await authorizationAccessor
+                .RequestAccessTokenAsync();
+
+            var queryString = queryEngine
+                .BuildRelatedArtistsQueryString(artistId);
+
+            var relatedArtistsDto = await spotifyAccessor
+                .GetRelatedArtistsAsync(bearerToken, queryString);
+
+            return mapper
+                .Map<ViewModels.RelatedArtists>(relatedArtistsDto) ?? new ViewModels.RelatedArtists();
+        }
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/RelatedArtists.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/RelatedArtists.cs
@@ -1,0 +1,7 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class RelatedArtists
+    {
+        public Artist[] Artists { get; set; } = [];
+    }
+}

--- a/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/Interfaces/IQueryEngine.cs
@@ -56,5 +56,12 @@
             string? includeGroups, 
             int? limit, 
             int? offset);
+
+        /// <summary>
+        /// Responsible for building a query string that targets Spotify's Web API GET /artists/{id}/related-artists endpoint.
+        /// </summary>
+        /// <param name="artistId"></param>
+        /// <returns></returns>
+        string BuildRelatedArtistsQueryString(string artistId);
     }
 }

--- a/3. Engines/MusicAPI.Engines/QueryEngine.cs
+++ b/3. Engines/MusicAPI.Engines/QueryEngine.cs
@@ -80,5 +80,10 @@ namespace MusicAPI.Engines
 
             return requestString;
         }
+
+        public string BuildRelatedArtistsQueryString(string artistId)
+        {
+            return $"{SpotifyBaseUri}/artists/{artistId}/related-artists";
+        }
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/RelatedArtists.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/RelatedArtists.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class RelatedArtists
+    {
+        /// <summary>
+        /// An array of Artist Object.
+        /// </summary>
+        [JsonPropertyName("artists")]
+        public Artist[] Artists { get; set; } = [];
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/Interfaces/ISpotifyAccessor.cs
@@ -43,5 +43,13 @@ namespace MusicAPI.Accessors.Interfaces
         /// <param name="queryString"></param>
         /// <returns></returns>
         Task<Albums> GetArtistAlbumsAsync(string bearerToken, string queryString);
+
+        /// <summary>
+        /// Communicates with Spotify's Web API to retrieve related artists for a given artist.
+        /// </summary>
+        /// <param name="bearerToken"></param>
+        /// <param name="queryString"></param>
+        /// <returns></returns>
+        Task<RelatedArtists> GetRelatedArtistsAsync(string bearerToken, string queryString);
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -112,6 +112,27 @@ namespace MusicAPI.Accessors
             throw new HttpRequestException($"Unable to retrieve Artist Albums using the request {queryString}");
         }
 
+        public async Task<RelatedArtists> GetRelatedArtistsAsync(string bearerToken, string queryString)
+        {
+            ValidateParameters(bearerToken, queryString);
+
+            var response = await ExecuteGetRequest(bearerToken, queryString);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var responseContent = await response
+                    .Content
+                    .ReadAsStringAsync();
+
+                var relatedArtists = JsonSerializer
+                    .Deserialize<RelatedArtists>(responseContent);
+
+                return relatedArtists ?? new RelatedArtists();
+            }
+
+            throw new HttpRequestException($"Unable to retrieve related Artists using the requset {queryString}");
+        }
+
         private async Task<HttpResponseMessage> ExecuteGetRequest(string bearerToken, string queryString)
         {
             var httpClient = SetupHttpClient(bearerToken);

--- a/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
+++ b/4. Accessors/MusicAPI.Accessors/SpotifyAccessor.cs
@@ -130,7 +130,7 @@ namespace MusicAPI.Accessors
                 return relatedArtists ?? new RelatedArtists();
             }
 
-            throw new HttpRequestException($"Unable to retrieve related Artists using the requset {queryString}");
+            throw new HttpRequestException($"Unable to retrieve related Artists using the request {queryString}");
         }
 
         private async Task<HttpResponseMessage> ExecuteGetRequest(string bearerToken, string queryString)

--- a/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
+++ b/7. Unit Tests/MusicAPI.Engines.Tests/QueryEngineTests.cs
@@ -178,5 +178,21 @@
 
             Assert.That(queryString, Is.EqualTo(expectedQueryString));
         }
+
+        [Test]
+        public void BuildRelatedArtistsQueryString_ShouldReturnQueryString()
+        {
+            // Arrange
+            var queryEngine = new QueryEngine();
+
+            // Act
+            var queryString = queryEngine
+                .BuildRelatedArtistsQueryString("artistId");
+
+            // Assert
+            const string expectedQueryString = "https://api.spotify.com/v1/artists/artistId/related-artists";
+
+            Assert.That(queryString, Is.EqualTo(expectedQueryString));
+        }
     }
 }

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/RelatedArtistsMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/RelatedArtistsMappingProfileTests.cs
@@ -1,0 +1,51 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class RelatedArtistsMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(RelatedArtistsMappingProfile));
+                configuration.AddProfile(typeof(ArtistMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+                configuration.AddProfile(typeof(ImageMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void RelatedArtistsMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void RelatedArtists_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            var relatedArtistsDataTransferObject = new Accessors.DataTransferObjects.RelatedArtists
+            {
+                Artists =
+                [
+                    new Accessors.DataTransferObjects.Artist()
+                ]
+            };
+
+            // Act
+            var relatedArtistsViewModel = Mapper.Map<ViewModels.RelatedArtists>(relatedArtistsDataTransferObject);
+
+            // Assert
+            Assert.That(relatedArtistsViewModel.Artists, Is.Not.Null);
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/SpotifyManagerTests.cs
@@ -235,6 +235,49 @@ namespace MusicAPI.Managers.Tests
                     Times.Once());
         }
 
+        [Test]
+        public async Task GetRelatedArtistsAsync_ShouldReturnRelatedArtists()
+        {
+            // Arrange
+            var mockAuthorizationAccessor = GetMockAuthorizationAccessor();
+
+            var mockQueryEngine = new Mock<IQueryEngine>(MockBehavior.Strict);
+            mockQueryEngine
+                .Setup(queryEngine => queryEngine.BuildRelatedArtistsQueryString(
+                    It.IsAny<string>()))
+                .Returns("http://localhost");
+
+            var mockSpotifyAccessor = new Mock<ISpotifyAccessor>(MockBehavior.Strict);
+            mockSpotifyAccessor
+                .Setup(spotifyAccessor => spotifyAccessor.GetRelatedArtistsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(new Accessors.DataTransferObjects.RelatedArtists());
+
+            var mockMapper = new Mock<IMapper>(MockBehavior.Strict);
+            mockMapper
+                .Setup(mapper => mapper.Map<ViewModels.RelatedArtists>(It.IsAny<Accessors.DataTransferObjects.RelatedArtists>()))
+                .Returns(new ViewModels.RelatedArtists());
+
+            var spotifyManager = new SpotifyManager(
+                mockAuthorizationAccessor.Object,
+                mockMapper.Object,
+                mockSpotifyAccessor.Object,
+                mockQueryEngine.Object);
+
+            // Act
+            var relatedArtists = await spotifyManager
+                .GetRelatedArtistsAsync("artistId");
+
+            // Assert
+            mockSpotifyAccessor
+                .Verify(
+                    spotifyAccessor => spotifyAccessor.GetRelatedArtistsAsync(
+                        It.Is<string>(bearerToken => bearerToken.Equals("Bearer Token")),
+                        It.Is<string>(queryString => queryString.Equals("http://localhost"))),
+                    Times.Once());
+        }
+
         private static Mock<IAuthorizationAccessor> GetMockAuthorizationAccessor()
         {
             var mockAuthorizationAccessor = new Mock<IAuthorizationAccessor>(MockBehavior.Strict);


### PR DESCRIPTION
This PR includes the following changes
- Adds new endpoint to ArtistController that retrieves related artists for a given ArtistId.
- Manager/Engine/Accessor methods to facilitate this data retrieval.
- Unit Test coverage for new methods introduced