### PR TITLE
Setup CORS policy for new AngularShowcase app

### DIFF
--- a/1. Clients/MusicAPI/Program.cs
+++ b/1. Clients/MusicAPI/Program.cs
@@ -12,6 +12,18 @@ builder.Services.AddControllers().AddJsonOptions(options =>
     options.JsonSerializerOptions.Converters.Add(enumConverter);
 });
 
+const string AngularShowcase = "AngularShowcase";
+var angularShowcaseOrigin = builder.Configuration.GetValue<string>("AngularShowcaseBaseUrl") ?? string.Empty;
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(name: AngularShowcase,
+        policy =>
+        {
+            policy.WithOrigins(angularShowcaseOrigin);
+        });
+});
+
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(configuration =>
@@ -51,6 +63,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseRouting();
+
+app.UseCors(AngularShowcase);
 
 app.UseHttpsRedirection();
 

--- a/1. Clients/MusicAPI/appsettings.json
+++ b/1. Clients/MusicAPI/appsettings.json
@@ -10,5 +10,6 @@
     "ClientId": "",
     "ClientSecret": "",
     "AuthorizationCode": ""
-  }
+  },
+  "AngularShowcaseBaseUrl": "http://localhost:4200"
 }


### PR DESCRIPTION
I started working on an Angular app to consume this API as part of building my portfolio. This PR includes some changes to support a configuration drive CORS policy if these ever gets deployed anywhere. Still no plans to do so quite yet