### PR TITLE
Implement GET Playlist Search endpoint

### DIFF
--- a/1. Clients/MusicAPI/Controllers/ArtistController.cs
+++ b/1. Clients/MusicAPI/Controllers/ArtistController.cs
@@ -64,7 +64,7 @@ namespace MusicAPI.Controllers
             var searchResult = await spotifyManager
                 .GetSearchAsync(searchQuery, SearchType.Artist, marketCode, limit, offset, includeExternal);
 
-            return Ok(searchResult);
+            return Ok(searchResult.Artists);
         }
 
         /// <summary>

--- a/1. Clients/MusicAPI/Controllers/PlaylistController.cs
+++ b/1. Clients/MusicAPI/Controllers/PlaylistController.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using MusicAPI.Managers.Interfaces;
+using MusicAPI.Managers.ViewModels.Enums;
+using System.ComponentModel.DataAnnotations;
+
+namespace MusicAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PlaylistController(ISpotifyManager spotifyManager) : ControllerBase
+    {
+        [HttpGet]
+        [Route("search")]
+        [Produces(typeof(OkObjectResult))]
+        public async Task<IActionResult> GetSearchAsync(
+            [Required] string searchQuery,
+            [Required] string marketCode,
+            int? limit = null,
+            int? offset = null,
+            string? includeExternal = null)
+        {
+            var searchResult = await spotifyManager
+                .GetSearchAsync(searchQuery, SearchType.Playlist, marketCode, limit, offset, includeExternal);
+
+            return Ok(searchResult.Playlists);
+        }
+    }
+}

--- a/1. Clients/MusicAPI/Controllers/PlaylistController.cs
+++ b/1. Clients/MusicAPI/Controllers/PlaylistController.cs
@@ -5,10 +5,35 @@ using System.ComponentModel.DataAnnotations;
 
 namespace MusicAPI.Controllers
 {
+    /// <summary>
+    /// Controler to retrieve data about Playlists from Spotify's Web API.
+    /// </summary>
+    /// <param name="spotifyManager"></param>
     [ApiController]
     [Route("api/[controller]")]
     public class PlaylistController(ISpotifyManager spotifyManager) : ControllerBase
     {
+        /// <summary>
+        /// Get Spotify Catalog information about playlists that match a keyword string.
+        /// </summary>
+        /// <param name="searchQuery">
+        ///     The Search Query.
+        /// </param>
+        /// <param name="marketCode">
+        ///     An ISO 3166-1 alpha-2 country code.
+        /// </param>
+        /// <param name="limit">
+        ///     The maximum number of results to return in each item type.
+        /// </param>
+        /// <param name="offset">
+        ///     The index of the first result to return. Use with limit to get the next page of search results.
+        /// </param>
+        /// <param name="includeExternal">
+        ///     If include_external=audio is specified, it signals that the client can play externally hosted audio content,
+        ///     and marks the content as playable in the response. By default externally hosted audio content is marked as unplayable 
+        ///     in the response.
+        /// </param>
+        /// <returns></returns>
         [HttpGet]
         [Route("search")]
         [Produces(typeof(OkObjectResult))]

--- a/2. Managers/MusicAPI.Managers/Mapping/OwnerMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/OwnerMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class OwnerMappingProfile : Profile
+    {
+        public OwnerMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.Owner, ViewModels.Owner>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/Mapping/PlaylistMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/PlaylistMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class PlaylistMappingProfile : Profile
+    {
+        public PlaylistMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.Playlist, ViewModels.Playlist>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/Mapping/PlaylistsMappingProfile.cs
+++ b/2. Managers/MusicAPI.Managers/Mapping/PlaylistsMappingProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+
+namespace MusicAPI.Managers.Mapping
+{
+    public class PlaylistsMappingProfile : Profile
+    {
+        public PlaylistsMappingProfile()
+        {
+            CreateMap<Accessors.DataTransferObjects.Playlists, ViewModels.Playlists>();
+        }
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/Albums.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Albums.cs
@@ -1,19 +1,7 @@
 ﻿namespace MusicAPI.Managers.ViewModels
 {
-    public class Albums
+    public class Albums : BaseSearchResult
     {
-        public string Href { get; set; } = string.Empty;
-
-        public decimal Limit { get; set; } = 0;
-
-        public string Next { get; set; } = string.Empty;
-
-        public decimal Offset { get; set; } = 0;
-
-        public string Previous { get; set; } = string.Empty;
-
-        public decimal Total { get; set; } = 0;
-
         public Album[] Items { get; set; } = [];
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/Artists.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Artists.cs
@@ -1,19 +1,7 @@
 ﻿namespace MusicAPI.Managers.ViewModels
 {
-    public class Artists
+    public class Artists : BaseSearchResult
     {
-        public string Href { get; set; } = string.Empty;
-
-        public int Limit { get; set; } = 0;
-
-        public string Next { get; set; } = string.Empty;
-
-        public int Offset { get; set; } = 0;
-
-        public string Previous { get; set; } = string.Empty;
-
-        public int Total { get; set; } = 0;
-
         public Artist[] Items { get; set; } = [];
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/BaseSearchResult.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/BaseSearchResult.cs
@@ -1,0 +1,17 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public abstract class BaseSearchResult
+    {
+        public string Href { get; set; } = string.Empty;
+
+        public decimal Limit { get; set; } = 0;
+
+        public string Next { get; set; } = string.Empty;
+
+        public decimal Offset { get; set; } = 0;
+
+        public string Previous { get; set; } = string.Empty;
+
+        public decimal Total { get; set; } = 0;
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/Image.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Image.cs
@@ -4,8 +4,8 @@
     {
         public string Url { get; set; } = string.Empty;
 
-        public int Height { get; set; } = 0;
+        public int? Height { get; set; } = 0;
 
-        public int Width { get; set; } = 0;
+        public int? Width { get; set; } = 0;
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/Owner.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Owner.cs
@@ -1,0 +1,19 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class Owner
+    {
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        public Followers Followers { get; set; } = new Followers();
+
+        public string Href { get; set; } = string.Empty;
+
+        public string Id { get; set; } = string.Empty;
+
+        public string Type { get; set; } = string.Empty;
+
+        public string Uri { get; set; } = string.Empty;
+
+        public string DisplayName { get; set; } = string.Empty;
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/Playlist.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Playlist.cs
@@ -1,0 +1,27 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class Playlist
+    {
+        public bool Collaborative { get; set; }
+
+        public string Description { get; set; } = string.Empty;
+
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        public string Href { get; set; } = string.Empty;
+
+        public Image[] Images { get; set; } = [];
+
+        public string Name { get; set; } = string.Empty;
+
+        public Owner Owner { get; set; } = new Owner();
+
+        public bool? Public { get; set; }
+
+        public string SnapshotId { get; set; } = string.Empty;
+
+        public string Type { get; set; } = string.Empty;
+
+        public string Uri { get; set; } = string.Empty;
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/Playlists.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/Playlists.cs
@@ -1,0 +1,7 @@
+﻿namespace MusicAPI.Managers.ViewModels
+{
+    public class Playlists : BaseSearchResult
+    {
+        public Playlist[] Items { get; set; } = [];
+    }
+}

--- a/2. Managers/MusicAPI.Managers/ViewModels/SearchResult.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/SearchResult.cs
@@ -3,5 +3,7 @@
     public class SearchResult
     {
         public Artists Artists { get; set; } = new Artists();
+
+        public Playlists Playlists { get; set; } = new Playlists();
     }
 }

--- a/2. Managers/MusicAPI.Managers/ViewModels/UserProfile.cs
+++ b/2. Managers/MusicAPI.Managers/ViewModels/UserProfile.cs
@@ -2,44 +2,28 @@
 {
     public class UserProfile
     {
-        public UserProfile()
-        {
-            Country = string.Empty;
-            DisplayName = string.Empty;
-            EmailAddress = string.Empty;
-            ExplicitContentFilter = new ExplicitContentFilter();
-            ExternalUrls = new ExternalUrl();
-            Followers = new Followers();
-            Href = string.Empty;
-            Id = string.Empty;
-            Images = [];
-            Product = string.Empty;
-            Type = string.Empty;
-            Uri = string.Empty;
-        }
+        public string Country { get; set; } = string.Empty;
 
-        public string Country { get; set; }
+        public string DisplayName { get; set; } = string.Empty;
 
-        public string DisplayName { get; set; }
+        public string EmailAddress { get; set; } = string.Empty;
 
-        public string EmailAddress { get; set; }
+        public ExplicitContentFilter ExplicitContentFilter { get; set; } = new ExplicitContentFilter();
 
-        public ExplicitContentFilter ExplicitContentFilter { get; set; }
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
 
-        public ExternalUrl ExternalUrls { get; set; }
+        public Followers Followers { get; set; } = new Followers();
 
-        public Followers Followers { get; set; }
+        public string Href { get; set; } = string.Empty;
 
-        public string Href { get; set; }
+        public string Id { get; set; } = string.Empty;
 
-        public string Id { get; set; }
+        public Image[] Images { get; set; } = [];
 
-        public Image[] Images { get; set; }
+        public string Product { get; set; } = string.Empty;
 
-        public string Product { get; set; }
+        public string Type { get; set; } = string.Empty;
 
-        public string Type { get; set; }
-
-        public string Uri { get; set; }
+        public string Uri { get; set; } = string.Empty;
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Albums.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Albums.cs
@@ -2,44 +2,8 @@
 
 namespace MusicAPI.Accessors.DataTransferObjects
 {
-    public class Albums
+    public class Albums : BaseSearchResult
     {
-        /// <summary>
-        /// A link to the Web API endpoint returning the full result of the request.
-        /// </summary>
-        [JsonPropertyName("href")]
-        public string Href { get; set; } = string.Empty;
-
-        /// <summary>
-        /// The maximum number of items in the reponse (as set in the query or by default).
-        /// </summary>
-        [JsonPropertyName("limit")]
-        public decimal Limit { get; set; } = 0;
-
-        /// <summary>
-        /// URL to the next page of items. (null if none)
-        /// </summary>
-        [JsonPropertyName("next")]
-        public string Next { get; set; } = string.Empty;
-
-        /// <summary>
-        /// The offset of the items returned (as set in the query or by default).
-        /// </summary>
-        [JsonPropertyName("offset")]
-        public decimal Offset { get; set; } = 0;
-
-        /// <summary>
-        /// URL to the previous page of items (null if none).
-        /// </summary>
-        [JsonPropertyName("previous")]
-        public string Previous { get; set; } = string.Empty;
-
-        /// <summary>
-        /// The total number of items available to return.
-        /// </summary>
-        [JsonPropertyName("total")]
-        public decimal Total { get; set; } = 0;
-
         /// <summary>
         /// Array of Albums objects.
         /// </summary>

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/BaseSearchResult.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/BaseSearchResult.cs
@@ -1,0 +1,43 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public abstract class BaseSearchResult
+    {
+        /// <summary>
+        /// A link to the Web API endpoint returning the full result of the request.
+        /// </summary>
+        [JsonPropertyName("href")]
+        public string Href { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The maximum number of items in the reponse (as set in the query or by default).
+        /// </summary>
+        [JsonPropertyName("limit")]
+        public int Limit { get; set; } = 0;
+
+        /// <summary>
+        /// URL to the next page of items. (null if none)
+        /// </summary>
+        [JsonPropertyName("next")]
+        public string Next { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The offset of the items returned (as set in the query or by default).
+        /// </summary>
+        [JsonPropertyName("offset")]
+        public int Offset { get; set; } = 0;
+
+        /// <summary>
+        /// URL to the previous page of items (null if none).
+        /// </summary>
+        [JsonPropertyName("previous")]
+        public string Previous { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The total number of items available to return.
+        /// </summary>
+        [JsonPropertyName("total")]
+        public int Total { get; set; } = 0;
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/BaseSearchResult.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/BaseSearchResult.cs
@@ -14,7 +14,7 @@ namespace MusicAPI.Accessors.DataTransferObjects
         /// The maximum number of items in the reponse (as set in the query or by default).
         /// </summary>
         [JsonPropertyName("limit")]
-        public int Limit { get; set; } = 0;
+        public decimal Limit { get; set; } = 0;
 
         /// <summary>
         /// URL to the next page of items. (null if none)
@@ -26,7 +26,7 @@ namespace MusicAPI.Accessors.DataTransferObjects
         /// The offset of the items returned (as set in the query or by default).
         /// </summary>
         [JsonPropertyName("offset")]
-        public int Offset { get; set; } = 0;
+        public decimal Offset { get; set; } = 0;
 
         /// <summary>
         /// URL to the previous page of items (null if none).
@@ -38,6 +38,6 @@ namespace MusicAPI.Accessors.DataTransferObjects
         /// The total number of items available to return.
         /// </summary>
         [JsonPropertyName("total")]
-        public int Total { get; set; } = 0;
+        public decimal Total { get; set; } = 0;
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Image.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Image.cs
@@ -17,12 +17,12 @@ namespace MusicAPI.Accessors.DataTransferObjects
         /// The image height in pixels.
         /// </summary>
         [JsonPropertyName("height")]
-        public decimal Height { get; set; } = 0;
+        public decimal? Height { get; set; } = 0;
 
         /// <summary>
         /// The image width in pixels.
         /// </summary>
         [JsonPropertyName("width")]
-        public decimal Width { get; set; } = 0;
+        public decimal? Width { get; set; } = 0;
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Owner.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Owner.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class Owner
+    {
+        /// <summary>
+        /// Known public external URL's for this user.
+        /// </summary>
+        [JsonPropertyName("external_urls")]
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        /// <summary>
+        /// Information about the followers of this user.
+        /// </summary>
+        [JsonPropertyName("followers")]
+        public Followers Followers { get; set; } = new Followers();
+
+        /// <summary>
+        /// A link to the Web API endpoint for this user.
+        /// </summary>
+        [JsonPropertyName("href")]
+        public string Href { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Spotify User ID for this user.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The object type. Allowed value is "user".
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Spotify URI for this user.
+        /// </summary>
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The name displayed on the user's profile. Null if not available.
+        /// </summary>
+        [JsonPropertyName("display_name")]
+        public string DisplayName { get; set; } = string.Empty;
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Playlist.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Playlist.cs
@@ -1,0 +1,74 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MusicAPI.Accessors.DataTransferObjects
+{
+    public class Playlist
+    {
+        /// <summary>
+        /// True if the owner allows other users to modify the playlist.
+        /// </summary>
+        [JsonPropertyName("collaborative")]
+        public bool Collaborative { get; set; }
+
+        /// <summary>
+        /// The playlist description. Only returned for modified, verified playlists, otherwise null.
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Known external URL's for this playlist.
+        /// </summary>
+        [JsonPropertyName("external_urls")]
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
+
+        /// <summary>
+        /// A link to the Web API endpoint providing full details of the playlist.
+        /// </summary>
+        [JsonPropertyName("href")]
+        public string Href { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Images for the playlist. The array may be empty or contain up to three images.
+        /// </summary>
+        [JsonPropertyName("images")]
+        public Image[] Images { get; set; } = [];
+
+        /// <summary>
+        /// The name of the playlist.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The user who owns the playlist.
+        /// </summary>
+        [JsonPropertyName("owner")]
+        public Owner Owner { get; set; } = new Owner();
+
+        /// <summary>
+        /// The playlist's public/private status: true if the playlist is public, false if the playlist is private, null 
+        /// if teh playlist status is not relevant.
+        /// </summary>
+        [JsonPropertyName("public")]
+        public bool? Public { get; set; }
+
+        /// <summary>
+        /// The version identifier for the current playlist. Can be supplied in other requests to target a specific playlist version.
+        /// </summary>
+        [JsonPropertyName("snapshot_id")]
+        public string SnapshotId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The object type: "Playlist"
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Spotify URI for the playlist.
+        /// </summary>
+        [JsonPropertyName("uri")]
+        public string Uri { get; set; } = string.Empty;
+    }
+}

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Playlists.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Playlists.cs
@@ -2,9 +2,9 @@
 
 namespace MusicAPI.Accessors.DataTransferObjects
 {
-    public class Artists : BaseSearchResult
+    public class Playlists : BaseSearchResult
     {
         [JsonPropertyName("items")]
-        public Artist[] Items { get; set; } = [];
+        public Playlist[] Items { get; set; } = [];
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/SearchResult.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/SearchResult.cs
@@ -6,5 +6,8 @@ namespace MusicAPI.Accessors.DataTransferObjects
     {
         [JsonPropertyName("artists")]
         public Artists Artists { get; set; } = new Artists();
+
+        [JsonPropertyName("playlists")]
+        public Playlists Playlists { get; set; } = new Playlists();
     }
 }

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Track.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/Track.cs
@@ -72,8 +72,6 @@ namespace MusicAPI.Accessors.DataTransferObjects
         [JsonPropertyName("is_playable")]
         public bool IsPlayable { get; set; }
 
-        // TODO: Look more into the Linked_From object
-
         /// <summary>
         /// Included in the response when a content restriction is applied.
         /// </summary>

--- a/4. Accessors/MusicAPI.Accessors/DataTransferObjects/UserProfile.cs
+++ b/4. Accessors/MusicAPI.Accessors/DataTransferObjects/UserProfile.cs
@@ -7,78 +7,62 @@ namespace MusicAPI.Accessors.DataTransferObjects
     /// </summary>
     public class UserProfile
     {
-        public UserProfile()
-        {
-            Country = string.Empty;
-            DisplayName = string.Empty;
-            EmailAddress = string.Empty;
-            ExplicitContentFilter = new ExplicitContentFilter();
-            ExternalUrls = new ExternalUrl();
-            Followers = new Followers();
-            Href = string.Empty;
-            Id = string.Empty;
-            Images = [];
-            Product = string.Empty;
-            Type = string.Empty;
-            Uri = string.Empty;
-        }
-
         /// <summary>
         /// The countery of the user, as set in the user's account profile. This field is only available when
         /// the current user has granted access to the user-read-private scope.
         /// </summary>
         [JsonPropertyName("country")]
-        public string Country { get; set; }
+        public string Country { get; set; } = string.Empty;
 
         /// <summary>
         /// The name displayed on the user's profile.
         /// </summary>
         [JsonPropertyName("display_name")]
-        public string DisplayName { get; set; }
+        public string DisplayName { get; set; } = string.Empty;
 
         /// <summary>
         /// The user's email address as entered by the user when creating their account. This field is only available when
         /// the current suer has granted access to the user-read-email scope.
         /// </summary>
         [JsonPropertyName("email")]
-        public string EmailAddress { get; set; }
+        public string EmailAddress { get; set; } = string.Empty;
 
         /// <summary>
         /// The user's explicit content settings. This field is only available when the current user has granted 
         /// access to the user-read-private scope.
         /// </summary>
         [JsonPropertyName("explicit_content")]
-        public ExplicitContentFilter ExplicitContentFilter { get; set; }
+        public ExplicitContentFilter ExplicitContentFilter { get; set; } = new ExplicitContentFilter();
 
         /// <summary>
         /// Known external URL's for the user.
         /// </summary>
         [JsonPropertyName("external_urls")]
-        public ExternalUrl ExternalUrls { get; set; }
+        public ExternalUrl ExternalUrls { get; set; } = new ExternalUrl();
 
         /// <summary>
         /// Information about the followers of the user.
         /// </summary>
         [JsonPropertyName("followers")]
-        public Followers Followers { get; set; }
+        public Followers Followers { get; set; } = new Followers();
 
         /// <summary>
         /// A link to the Web API endpoint for this user.
         /// </summary>
         [JsonPropertyName("href")]
-        public string Href { get; set; }
+        public string Href { get; set; } = string.Empty;
 
         /// <summary>
         /// The Spotify User ID for the user.
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; set; } = string.Empty;
 
         /// <summary>
         /// The user's profile image.
         /// </summary>
         [JsonPropertyName("images")]
-        public Image[] Images { get; set; }
+        public Image[] Images { get; set; } = [];
 
         /// <summary>
         /// The user's Spotify subscrption level: "premium", "free", etc.
@@ -86,18 +70,18 @@ namespace MusicAPI.Accessors.DataTransferObjects
         /// user has granted access to the user-read-private scope.
         /// </summary>
         [JsonPropertyName("product")]
-        public string Product { get; set; }
+        public string Product { get; set; } = string.Empty;
 
         /// <summary>
         /// The object type: "user"
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get; set; }
+        public string Type { get; set; } = string.Empty;
 
         /// <summary>
         /// The Spotify URI for the user.
         /// </summary>
         [JsonPropertyName("uri")]
-        public string Uri { get; set; }
+        public string Uri { get; set; } = string.Empty;
     }
 }

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/OwnerMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/OwnerMappingProfileTests.cs
@@ -1,0 +1,67 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class OwnerMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(OwnerMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void OwnerMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void Owner_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedHref = "href";
+            const string expectedId = "id";
+            const string expectedType = "type";
+            const string expectedUri = "uri";
+            const string expectedDisplayName = "displayName";
+
+            var ownerDataTransferObject = new Accessors.DataTransferObjects.Owner
+            {
+                ExternalUrls = new Accessors.DataTransferObjects.ExternalUrl(),
+                Followers = new Accessors.DataTransferObjects.Followers(),
+                Href = expectedHref,
+                Id = expectedId,
+                Type = expectedType,
+                Uri = expectedUri,
+                DisplayName = expectedDisplayName
+            };
+
+            // Act
+            var ownerViewModel = Mapper.Map<ViewModels.Owner>(ownerDataTransferObject);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(ownerViewModel.ExternalUrls, Is.Not.Null);
+                Assert.That(ownerViewModel.Followers, Is.Not.Null);
+                Assert.That(ownerViewModel.Href, Is.EqualTo(expectedHref));
+                Assert.That(ownerViewModel.Id, Is.EqualTo(expectedId));
+                Assert.That(ownerViewModel.Type, Is.EqualTo(expectedType));
+                Assert.That(ownerViewModel.Uri, Is.EqualTo(expectedUri));
+                Assert.That(ownerViewModel.DisplayName, Is.EqualTo(expectedDisplayName));
+            });
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/PlaylistMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/PlaylistMappingProfileTests.cs
@@ -1,0 +1,81 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class PlaylistMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(PlaylistMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(ImageMappingProfile));
+                configuration.AddProfile(typeof(OwnerMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void PlaylistMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void Playlist_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedDescription = "description";
+            const string expectedHref = "href";
+            const string expectedName = "name";
+            const string expectedSnapshotId = "Snapshot id";
+            const string expectedType = "type";
+            const string expectedUri = "uri";
+
+            var playlistDataTransferObject = new Accessors.DataTransferObjects.Playlist
+            {
+                Collaborative = true,
+                Description = expectedDescription,
+                ExternalUrls = new Accessors.DataTransferObjects.ExternalUrl(),
+                Href = expectedHref,
+                Images =
+                [
+                    new Accessors.DataTransferObjects.Image()
+                ],
+                Name = expectedName,
+                Owner = new Accessors.DataTransferObjects.Owner(),
+                Public = true,
+                SnapshotId = expectedSnapshotId,
+                Type = expectedType,
+                Uri = expectedUri
+            };
+
+            // Act
+            var playlistViewModel = Mapper.Map<ViewModels.Playlist>(playlistDataTransferObject);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(playlistViewModel.Collaborative, Is.True);
+                Assert.That(playlistViewModel.Description, Is.EqualTo(expectedDescription));
+                Assert.That(playlistViewModel.ExternalUrls, Is.Not.Null);
+                Assert.That(playlistViewModel.Href, Is.EqualTo(expectedHref));
+                Assert.That(playlistViewModel.Images, Is.Not.Null);
+                Assert.That(playlistViewModel.Name, Is.EqualTo(expectedName));
+                Assert.That(playlistViewModel.Owner, Is.Not.Null);
+                Assert.That(playlistViewModel.Public, Is.True);
+                Assert.That(playlistViewModel.SnapshotId, Is.EqualTo(expectedSnapshotId));
+                Assert.That(playlistViewModel.Type, Is.EqualTo(expectedType));
+                Assert.That(playlistViewModel.Uri, Is.EqualTo(expectedUri));
+            });
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/PlaylistsMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/PlaylistsMappingProfileTests.cs
@@ -1,0 +1,71 @@
+﻿namespace MusicAPI.Managers.Tests.Mapping
+{
+#pragma warning disable CS8602
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class PlaylistsMappingProfileTests
+    {
+        private IMapper Mapper { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mapperConfiguration = new MapperConfiguration(configuration =>
+            {
+                configuration.AddProfile(typeof(PlaylistsMappingProfile));
+                configuration.AddProfile(typeof(PlaylistMappingProfile));
+                configuration.AddProfile(typeof(ExternalUrlMappingProfile));
+                configuration.AddProfile(typeof(ImageMappingProfile));
+                configuration.AddProfile(typeof(OwnerMappingProfile));
+                configuration.AddProfile(typeof(FollowersMappingProfile));
+            });
+
+            Mapper = mapperConfiguration.CreateMapper();
+        }
+
+        [Test]
+        public void PlaylistsMappingProfile_AssertConfigurationIsValid()
+        {
+            // Act & Assert
+            Mapper.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        [Test]
+        public void Playlists_DataTransferObject_To_ViewModel_ShouldMap()
+        {
+            // Arrange
+            const string expectedPlaylistsHref = "Expected Playlists Href";
+            const string expectedNext = "Expected Next";
+            const string expectedPrevious = "Expected Previous";
+
+            var playlistsDataTransferObject = new Accessors.DataTransferObjects.Playlists
+            {
+                Href = expectedPlaylistsHref,
+                Limit = 1,
+                Next = expectedNext,
+                Offset = 2,
+                Previous = expectedPrevious,
+                Total = 3,
+                Items =
+                [
+                    new Accessors.DataTransferObjects.Playlist()
+                ]
+            };
+
+            // Act
+            var playlistsViewModel = Mapper.Map<ViewModels.Playlists>(playlistsDataTransferObject);
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(playlistsViewModel.Href, Is.EqualTo(expectedPlaylistsHref));
+                Assert.That(playlistsViewModel.Limit, Is.EqualTo(1));
+                Assert.That(playlistsViewModel.Next, Is.EqualTo(expectedNext));
+                Assert.That(playlistsViewModel.Offset, Is.EqualTo(2));
+                Assert.That(playlistsViewModel.Previous, Is.EqualTo(expectedPrevious));
+                Assert.That(playlistsViewModel.Total, Is.EqualTo(3));
+                Assert.That(playlistsViewModel.Items, Is.Not.Null);
+            });
+        }
+    }
+}

--- a/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/SearchResultMappingProfileTests.cs
+++ b/7. Unit Tests/MusicAPI.Managers.UnitTests/Mapping/SearchResultMappingProfileTests.cs
@@ -18,6 +18,10 @@
                 configuration.AddProfile(typeof(ExternalUrlMappingProfile));
                 configuration.AddProfile(typeof(FollowersMappingProfile));
                 configuration.AddProfile(typeof(ImageMappingProfile));
+
+                configuration.AddProfile(typeof(PlaylistsMappingProfile));
+                configuration.AddProfile(typeof(PlaylistMappingProfile));
+                configuration.AddProfile(typeof(OwnerMappingProfile));
             });
 
             Mapper = mapperConfiguration.CreateMapper();
@@ -40,6 +44,10 @@
                 Artists = new Accessors.DataTransferObjects.Artists
                 {
                     Total = 5
+                },
+                Playlists = new Accessors.DataTransferObjects.Playlists
+                {
+                    Total = 10
                 }
             };
 
@@ -50,6 +58,7 @@
             Assert.Multiple(() =>
             {
                 Assert.That(searchResultViewModel.Artists.Total, Is.EqualTo(5));
+                Assert.That(searchResultDataTransferObject.Playlists.Total, Is.EqualTo(10));
             });
         }
     }


### PR DESCRIPTION
This PR includes the following updates:
- Adds new controller for Playlist data retrieval
- ViewModel and DTO creation to support Playlist search on existing SearchResult object
- Abstracted out properties on objects to remove duplicate property creation when appropriate (Artists, Playlists)
- New Mapping profiles to support Playlist search

NOTE: This PR does update the response in Artist search to return only the Artist related content. An update will need to be made in the Angular showcase project to support this 